### PR TITLE
Styling fixes for start page.

### DIFF
--- a/_sections/start/elearning.md
+++ b/_sections/start/elearning.md
@@ -3,9 +3,9 @@ year: start
 title: E-learning
 ---
 
-- Blackboard app for [Android](https://play.google.com/store/apps/details?id=com.blackboard.android), [iOS](https://itunes.apple.com/us/app/blackboard-mobile-learn/id376413870?mt=8)
-- Linear Algebra by Prof. Gilbert Strang - [MIT 18.06](http://ocw.mit.edu/courses/mathematics/18-06-linear-algebra-spring-2010/)
-- Russel and Norvig's online AI Class from Stanford - [https://www.ai-class.com/](https://www.ai-class.com/accessibility)
-- MIT OpenCourseware Mathematics - [http://ocw.mit.edu/courses/mathematics/](http://ocw.mit.edu/courses/mathematics/)
-- Accessible videos about cryptography - [http://www.youtube.com/playlist?list=PLB4D701646DAF0817](http://www.youtube.com/playlist?list=PLB4D701646DAF0817)
-- The Google [tech dev guide](https://techdevguide.withgoogle.com) is also a good place to get some practice.
+* Blackboard app for [Android](https://play.google.com/store/apps/details?id=com.blackboard.android), [iOS](https://itunes.apple.com/us/app/blackboard-mobile-learn/id376413870?mt=8)
+* Linear Algebra by Prof. Gilbert Strang - [MIT 18.06](http://ocw.mit.edu/courses/mathematics/18-06-linear-algebra-spring-2010/)
+* Russel and Norvig's online AI Class from Stanford - [https://www.ai-class.com/](https://www.ai-class.com/accessibility)
+* MIT OpenCourseware Mathematics - [http://ocw.mit.edu/courses/mathematics/](http://ocw.mit.edu/courses/mathematics/)
+* Accessible videos about cryptography - [http://www.youtube.com/playlist?list=PLB4D701646DAF0817](http://www.youtube.com/playlist?list=PLB4D701646DAF0817)
+* The Google [tech dev guide](https://techdevguide.withgoogle.com) is also a good place to get some practice.

--- a/_sections/start/exam-related.md
+++ b/_sections/start/exam-related.md
@@ -3,6 +3,6 @@ year: start
 title: Exam Related
 ---
 
-- Exam papers: [via the ITO](http://www.inf.ed.ac.uk/teaching/exam_papers/), [via the library](http://www.exampapers.lib.ed.ac.uk.ezproxy.webfeat.lib.ed.ac.uk/Informatics0405.shtml)
-- [Exam statistics](http://www.inf.ed.ac.uk/student-services/teaching-organisation/taught-course-information/course-statistics/summary)
-- [Exam timetable from the registry](http://www.scripts.sasg.ed.ac.uk/registry/examinations/index.cfm)
+* Exam papers: [via the ITO](http://www.inf.ed.ac.uk/teaching/exam_papers/), [via the library](http://www.exampapers.lib.ed.ac.uk.ezproxy.webfeat.lib.ed.ac.uk/Informatics0405.shtml)
+* [Exam statistics](http://www.inf.ed.ac.uk/student-services/teaching-organisation/taught-course-information/course-statistics/summary)
+* [Exam timetable from the registry](http://www.scripts.sasg.ed.ac.uk/registry/examinations/index.cfm)

--- a/_sections/start/exam-related.md
+++ b/_sections/start/exam-related.md
@@ -3,6 +3,6 @@ year: start
 title: Exam Related
 ---
 
-- exam papers: [via the ITO](http://www.inf.ed.ac.uk/teaching/exam_papers/), [via the library](http://www.exampapers.lib.ed.ac.uk.ezproxy.webfeat.lib.ed.ac.uk/Informatics0405.shtml)
-- [exam statistics](http://www.inf.ed.ac.uk/student-services/teaching-organisation/taught-course-information/course-statistics/summary)
-- [exam timetable from the registry](http://www.scripts.sasg.ed.ac.uk/registry/examinations/index.cfm)
+- Exam papers: [via the ITO](http://www.inf.ed.ac.uk/teaching/exam_papers/), [via the library](http://www.exampapers.lib.ed.ac.uk.ezproxy.webfeat.lib.ed.ac.uk/Informatics0405.shtml)
+- [Exam statistics](http://www.inf.ed.ac.uk/student-services/teaching-organisation/taught-course-information/course-statistics/summary)
+- [Exam timetable from the registry](http://www.scripts.sasg.ed.ac.uk/registry/examinations/index.cfm)

--- a/_sections/start/technical.md
+++ b/_sections/start/technical.md
@@ -4,7 +4,7 @@ title: Technical
 ---
 
 * [Set your initial DICE password](http://pp.inf.ed.ac.uk/)
-* Web printing interfaces: [EveryonePrint](https://www.everyoneprint.is.ed.ac.uk), [WebPrint](https://webprint.inf.ed.ac.uk)
+- **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
 * [Print balance](https://www.manageprint.is.ed.ac.uk/)
 * [Access DICE files in a web browser](https://ifile.inf.ed.ac.uk/)
 * [Accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)

--- a/_sections/start/technical.md
+++ b/_sections/start/technical.md
@@ -3,24 +3,14 @@ year: start
 title: Technical
 ---
 
-[Set your initial DICE password](http://pp.inf.ed.ac.uk/)
-
-web printing interfaces: [EveryonePrint](https://www.everyoneprint.is.ed.ac.uk), [WebPrint](https://webprint.inf.ed.ac.uk)
-
-[print balance](https://www.manageprint.is.ed.ac.uk/)
-
-[Access DICE files in a web browser](https://ifile.inf.ed.ac.uk/)
-
-[accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)
-
-[DICE software packages search](http://pkgsearch.inf.ed.ac.uk/pkgsearch.shtml)
-
-[Virtual DICE for use in a VM](http://computing.help.inf.ed.ac.uk/vdice) : Supports VirtualBox, VMWare support under development
-
-[University VPN service](http://www.ed.ac.uk/schools-departments/information-services/services/computing/desktop-personal/vpn/vpn-service-using)
-
-[DICE contact form](https://www.inf.ed.ac.uk/systems/support/form/) (computing support)
-
-[Information Services contact form](https://ed.unidesk.ac.uk/tas/public/)
-
-unsubscribing from a mailing list: email `majordomo@lists.ed.ac.uk` with `unsubscribe` in the message body
+* [Set your initial DICE password](http://pp.inf.ed.ac.uk/)
+* web printing interfaces: [EveryonePrint](https://www.everyoneprint.is.ed.ac.uk), [WebPrint](https://webprint.inf.ed.ac.uk)
+* [print balance](https://www.manageprint.is.ed.ac.uk/)
+* [Access DICE files in a web browser](https://ifile.inf.ed.ac.uk/)
+* [accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)
+* [DICE software packages search](http://pkgsearch.inf.ed.ac.uk/pkgsearch.shtml)
+* [Virtual DICE for use in a VM](http://computing.help.inf.ed.ac.uk/vdice) : Supports VirtualBox, VMWare support under development
+* [University VPN service](http://www.ed.ac.uk/schools-departments/information-services/services/computing/desktop-personal/vpn/vpn-service-using)
+* [DICE contact form](https://www.inf.ed.ac.uk/systems/support/form/) (computing support)
+* [Information Services contact form](https://ed.unidesk.ac.uk/tas/public/)
+* unsubscribing from a mailing list: email `majordomo@lists.ed.ac.uk` with `unsubscribe` in the message body

--- a/_sections/start/technical.md
+++ b/_sections/start/technical.md
@@ -4,7 +4,7 @@ title: Technical
 ---
 
 * [Set your initial DICE password](http://pp.inf.ed.ac.uk/)
-- **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
+* **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
 * [Print balance](https://www.manageprint.is.ed.ac.uk/)
 * [Access DICE files in a web browser](https://ifile.inf.ed.ac.uk/)
 * [Accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)

--- a/_sections/start/technical.md
+++ b/_sections/start/technical.md
@@ -4,13 +4,13 @@ title: Technical
 ---
 
 * [Set your initial DICE password](http://pp.inf.ed.ac.uk/)
-* web printing interfaces: [EveryonePrint](https://www.everyoneprint.is.ed.ac.uk), [WebPrint](https://webprint.inf.ed.ac.uk)
-* [print balance](https://www.manageprint.is.ed.ac.uk/)
+* Web printing interfaces: [EveryonePrint](https://www.everyoneprint.is.ed.ac.uk), [WebPrint](https://webprint.inf.ed.ac.uk)
+* [Print balance](https://www.manageprint.is.ed.ac.uk/)
 * [Access DICE files in a web browser](https://ifile.inf.ed.ac.uk/)
-* [accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)
+* [Accessing DICE environment](http://computing.help.inf.ed.ac.uk/nx/)
 * [DICE software packages search](http://pkgsearch.inf.ed.ac.uk/pkgsearch.shtml)
 * [Virtual DICE for use in a VM](http://computing.help.inf.ed.ac.uk/vdice) : Supports VirtualBox, VMWare support under development
 * [University VPN service](http://www.ed.ac.uk/schools-departments/information-services/services/computing/desktop-personal/vpn/vpn-service-using)
 * [DICE contact form](https://www.inf.ed.ac.uk/systems/support/form/) (computing support)
 * [Information Services contact form](https://ed.unidesk.ac.uk/tas/public/)
-* unsubscribing from a mailing list: email `majordomo@lists.ed.ac.uk` with `unsubscribe` in the message body
+* Unsubscribing from a mailing list: email `majordomo@lists.ed.ac.uk` with `unsubscribe` in the message body

--- a/_sections/start/useful-links.md
+++ b/_sections/start/useful-links.md
@@ -7,7 +7,7 @@ ordering: -5
 - [Reading List](https://goo.gl/9NkLch)
 - [InfWeb](http://web.inf.ed.ac.uk/), [Staff and Student Rep Meetings blog](http://blog.inf.ed.ac.uk/issr/)
 - [The Marauders Map](https://map.betterinformatics.com) - map of machines
-- **Printing**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
+- **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
 - [List of all Informatics courses](http://course.inf.ed.ac.uk/)
 - [Progression Guidance](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/progression-guidance)
 - [Course survey reports](http://www.inf.ed.ac.uk/admin/ITO/course-survey-reports/)

--- a/_sections/start/useful-links.md
+++ b/_sections/start/useful-links.md
@@ -7,15 +7,15 @@ ordering: -5
 - [Reading List](https://goo.gl/9NkLch)
 - [InfWeb](http://web.inf.ed.ac.uk/), [Staff and Student Rep Meetings blog](http://blog.inf.ed.ac.uk/issr/)
 - [The Marauders Map](https://map.betterinformatics.com) - map of machines
-- **printing**: [everyoneprint](http://www.everyoneprint.is.ed.ac.uk), [webprint](http://webprint.inf.ed.ac.uk), [manageprint](http://www.manageprint.is.ed.ac.uk)
+- **Printing**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
 - [List of all Informatics courses](http://course.inf.ed.ac.uk/)
 - [Progression Guidance](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/progression-guidance)
-- [course survey reports](http://www.inf.ed.ac.uk/admin/ITO/course-survey-reports/)
-- [all recorded videos](http://groups.inf.ed.ac.uk/vision/VIDEO/) (*last update 15/16*)
+- [Course survey reports](http://www.inf.ed.ac.uk/admin/ITO/course-survey-reports/)
+- [All recorded videos](http://groups.inf.ed.ac.uk/vision/VIDEO/) (*last update 15/16*)
 - [ITO contact form](https://www.inf.ed.ac.uk/cgi-bin/iss/contact.cgi)
-- [student portal](https://student.inf.ed.ac.uk/) (with all your coursework marks)
-- [library](http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery)
-- [feedback policy](http://www.inf.ed.ac.uk/student-services/teaching-organisation/for-taught-students/coursework-and-projects/coursework-assessment-and-feedback)
+- [Student portal](https://student.inf.ed.ac.uk/) (with all your coursework marks)
+- [Library](http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery)
+- [Feedback policy](http://www.inf.ed.ac.uk/student-services/teaching-organisation/for-taught-students/coursework-and-projects/coursework-assessment-and-feedback)
 - Allocations for: [tutorials](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP072_Tutorial_Groups/), [labs](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP082_Laboratory_Groups/)
 
 <!--

--- a/_sections/start/useful-links.md
+++ b/_sections/start/useful-links.md
@@ -4,19 +4,19 @@ title: Useful Links
 ordering: -5
 ---
 
-- [Reading List](https://goo.gl/9NkLch)
-- [InfWeb](http://web.inf.ed.ac.uk/), [Staff and Student Rep Meetings blog](http://blog.inf.ed.ac.uk/issr/)
-- [The Marauders Map](https://map.betterinformatics.com) - map of machines
-- **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
-- [List of all Informatics courses](http://course.inf.ed.ac.uk/)
-- [Progression Guidance](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/progression-guidance)
-- [Course survey reports](http://www.inf.ed.ac.uk/admin/ITO/course-survey-reports/)
-- [All recorded videos](http://groups.inf.ed.ac.uk/vision/VIDEO/) (*last update 15/16*)
-- [ITO contact form](https://www.inf.ed.ac.uk/cgi-bin/iss/contact.cgi)
-- [Student portal](https://student.inf.ed.ac.uk/) (with all your coursework marks)
-- [Library](http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery)
-- [Feedback policy](http://www.inf.ed.ac.uk/student-services/teaching-organisation/for-taught-students/coursework-and-projects/coursework-assessment-and-feedback)
-- Allocations for: [tutorials](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP072_Tutorial_Groups/), [labs](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP082_Laboratory_Groups/)
+* [Reading List](https://goo.gl/9NkLch)
+* [InfWeb](http://web.inf.ed.ac.uk/), [Staff and Student Rep Meetings blog](http://blog.inf.ed.ac.uk/issr/)
+* [The Marauders Map](https://map.betterinformatics.com) - map of machines
+* **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [WebPrint](http://webprint.inf.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
+* [List of all Informatics courses](http://course.inf.ed.ac.uk/)
+* [Progression Guidance](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/progression-guidance)
+* [Course survey reports](http://www.inf.ed.ac.uk/admin/ITO/course-survey-reports/)
+* [All recorded videos](http://groups.inf.ed.ac.uk/vision/VIDEO/) (*last update 15/16*)
+* [ITO contact form](https://www.inf.ed.ac.uk/cgi-bin/iss/contact.cgi)
+* [Student portal](https://student.inf.ed.ac.uk/) (with all your coursework marks)
+* [Library](http://www.ed.ac.uk/schools-departments/information-services/library-museum-gallery)
+* [Feedback policy](http://www.inf.ed.ac.uk/student-services/teaching-organisation/for-taught-students/coursework-and-projects/coursework-assessment-and-feedback)
+* Allocations for: [tutorials](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP072_Tutorial_Groups/), [labs](https://portal.theon.inf.ed.ac.uk/reports/upt/open/TP082_Laboratory_Groups/)
 
 <!--
 - [Informatics Room Booking System](https://rbs.inf.ed.ac.uk/ito)
@@ -26,7 +26,7 @@ ordering: -5
 
 For courseworks issued more than 8 days in advance:
 
-- 5% will be deducted per calendar day, up to 7 days (unless you have a reason for extension)
-- you need to request an extension via the ITO contact form **IN ADVANCE** (unless possible)
-- [official policy](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/coursework-projects/late-coursework-extension-requests)
-  - there are **COURSE EXCEPTIONS** to the new policy, listed at the bottom of the linked policy page... no coursework will be accepted past the deadline unless an extension is approved.
+* 5% will be deducted per calendar day, up to 7 days (unless you have a reason for extension)
+* you need to request an extension via the ITO contact form **IN ADVANCE** (unless possible)
+* [official policy](http://web.inf.ed.ac.uk/infweb/student-services/ito/admin/coursework-projects/late-coursework-extension-requests)
+    * there are **COURSE EXCEPTIONS** to the new policy, listed at the bottom of the linked policy page... no coursework will be accepted past the deadline unless an extension is approved.


### PR DESCRIPTION
First and foremost, this makes the two "printing" related entries under Useful Links and Technical into the same looking line. The entry under Technical ignored one link, but had a better title, so I combined the two.

Second, "Technical" section is now a list, just like all other sections.

Third, capitalization is standardized.

Fourth, this makes the list starters consistent, turning them all into "\*" rather than a mixture of "\*" and "-". Considering the way the formatting is shown on the site as a bullet point, I thought "\*" more appropriate.