### PR TITLE
JQuery removal

### DIFF
--- a/_includes/exams.html
+++ b/_includes/exams.html
@@ -33,7 +33,6 @@
 }
 </style>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.16.0/moment.min.js"></script>
 <script>
     const courses = JSON.parse(`{{ site.data.courses | jsonify }}`);
@@ -41,12 +40,16 @@
     // console.log(pageCourses)
     const year = parseInt(`{{ page.year }}`);
 
-    const fail = () => $("#get-exam-timetable > a").text("something broke, sorry");
-    const success = (data) => $("#get-exam-timetable > a").text("view exams").click(() => {
-        showExamTimetable(data.data);
-        $("#get-exam-timetable").remove();
-        return false;
-    });
+    const fail = () => {document.querySelector("#get-exam-timetable > a").innerText = "something broke, sorry"}
+    const success = (data) => {
+        const el = document.querySelector("#get-exam-timetable > a")
+        el.innerText = "view exams"
+        el.addEventListener('click', () => {
+            showExamTimetable(data.data);
+            document.querySelector('#get-exam-timetable').remove();
+            return false;
+        });
+    }
 
     const readVenue = venues => {
         let s = '';
@@ -100,45 +103,44 @@
         results.sort((a, b) => {return a.time > b.time ? 1 : -1});
         // console.log(results)
 
-        const table = $("#exam-timetable-table");
-        const body = table.find('tbody');
-        body.html(``);
+        const table = document.querySelector("#exam-timetable-table");
+        const body = table.querySelector('tbody');
+        body.innerHTML = ''
 
         const clickyText = (t, a, b) => {
-            t.click(() => t.text(
-                t.text() === b ? a : b
-            ));
-            t.text(b);
+            t.addEventListener('click', () => {t.innerText = (t.innerText === b ? a : b)})
+            t.innerText = b
         }
 
         results.forEach(exam => {
-            const t = $("<td/>");
+            const t = document.createElement('td')
             clickyText(t, exam.title, exam.acronym);
             
             let shortVenue = exam.venue.slice(0, 80)
             if (shortVenue !== exam.venue) {
                 shortVenue + '...';
             }
-            const v = $("<td/>");
+            const v = document.createElement('td')
             clickyText(v, exam.venue, shortVenue);
             
-            const d = $("<td/>");
+            const d = document.createElement('td')
             clickyText(d, exam.timeAbs, exam.timeRel);
 
-            const tr = $("<tr/>");
-            // tr.append($("<td/>", {text:exam.acronym}));
-            tr.append(t);
-            tr.append(v);
-            tr.append(d);
+            const tr = document.createElement('tr')
+            tr.appendChild(t);
+            tr.appendChild(v);
+            tr.appendChild(d);
 
-            body.append(tr);
+            body.appendChild(tr);
         })
 
-        table.show();
+        table.style.display = 'block'
     }
 
-    $(() => {
-        $.ajax("https://betterinformatics.com/search/", {dataType: 'json'})
-        .done(data => success(data)).fail(fail);
-    })
+    window.onload = () => {
+        fetch('https://betterinformatics.com/search/')
+            .then(r => r.json())
+            .then(r => success(r))
+            .catch(() => fail())
+    }
 </script>

--- a/_includes/exams.html
+++ b/_includes/exams.html
@@ -137,10 +137,10 @@
         table.style.display = 'block'
     }
 
-    window.onload = () => {
+    window.addEventListener('load', () => {
         fetch('https://betterinformatics.com/search/')
             .then(r => r.json())
             .then(r => success(r))
             .catch(() => fail())
-    }
+    })
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,27 +26,32 @@
         </div>
 
         {% if page.layout == "frontpage" %}
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
             <script type="text/javascript">
-                $(() => {
+                window.onload = () => {
                     // If a course is provided, show everything
                     if (window.location.hash) {
-                        $("[data-semester]").show();
-                        $(location.hash).find("h3").css("background-color", "rgba(255, 255, 0, 0.2)")
+                        //$("[data-semester]").show();
+                        document.querySelectorAll('[data-semester]').forEach(e => e.style.display = 'block')
+                        //$(location.hash).find("h3").css("background-color", "rgba(255, 255, 0, 0.2)")
+                        document.querySelector(location.hash)
+                            .querySelector('h3')
+                            .style.backgroundColor = 'rgba(255,255,0,0.2)'
                     }
 
-                    $("#sem1-btn,#sem2-btn,#all-btn").click(btn => {
-                        // First show everything
-                        $("[data-semester]").show();
 
-                        var sem = btn.target.id.slice(3, 4);
-                        if (sem == "1") {
-                            $("[data-semester='2']").hide();
-                        } else if (sem == "2") {
-                            $("[data-semester='1']").hide();
-                        }
-                    });
-                })
+                    document.querySelectorAll('[data-sem]').forEach(el => {
+                        el.addEventListener('click', btn => {
+                            document.querySelectorAll('[data-semester]').forEach(e => e.style.display = 'block')
+
+
+                            if (el.dataset.sem == '1') {
+                                document.querySelectorAll('[data-semester="2"]').forEach(e => e.style.display = 'none')
+                            } else if (el.dataset.sem == '2') {
+                                document.querySelectorAll('[data-semester="1"]').forEach(e => e.style.display = 'none')
+                            }
+                        })
+                    })
+                }
             </script>
         {% endif %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
 
         {% if page.layout == "frontpage" %}
             <script type="text/javascript">
-                window.onload = () => {
+                window.addEventListener('load', () => {
                     // If a course is provided, show everything
                     if (window.location.hash) {
                         //$("[data-semester]").show();
@@ -51,7 +51,7 @@
                             }
                         })
                     })
-                }
+                })
             </script>
         {% endif %}
 

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -12,9 +12,9 @@ layout: default
 </div>
 
 {% if page.year and page.year != "start" %}
-    <a id="sem1-btn" class="btn">view semester 1</a>
-    <a id="sem2-btn" class="btn">view semester 2</a>
-    <a id="all-btn" class="btn">view all</a>
+    <a id="sem1-btn" data-sem="1"  class="btn">view semester 1</a>
+    <a id="sem2-btn" data-sem="2"  class="btn">view semester 2</a>
+    <a id="all-btn" data-sem="all" class="btn">view all</a>
 {% endif %}
 
 {{ content }}

--- a/_pages/calculator.html
+++ b/_pages/calculator.html
@@ -120,7 +120,6 @@ function updateCalculation() {
         || ((overall == "") && (exam != "") && (cw == ""))
     ) {
         console.log("At least 2 are empty.")
-        showCalculatorError('At least 2 are empty')
         return;
     }
 
@@ -228,11 +227,9 @@ function loadCourseCalculator() {
     document.querySelectorAll('[data-cw-lock]').forEach(el => el.addEventListener('click', handleLock))
 
 
-    // fire handler to initially populate the commits
-    try {
-        handleLock()
-    } catch (e) {}
+    // fire handler to initially populate the locks
+    handleLock.bind(document.querySelector('[data-cw-lock]'))()
 }
 
-window.onload = loadCourseCalculator
+window.addEventListener('load', loadCourseCalculator)
 </script>

--- a/_pages/calculator.html
+++ b/_pages/calculator.html
@@ -205,7 +205,7 @@ function changeCourse() {
         return;
     }
 
-    courseEl.style.display = 'block'
+    courseEl.style.display = null;
     courseEl.setAttribute('href', course.euclid_url)
 
     if (course.cw_exam_ratio === null) {

--- a/_pages/calculator.html
+++ b/_pages/calculator.html
@@ -27,9 +27,9 @@ layout: page
 
     {% assign courses = site.data.courses.list %}
     <select id="course-list">
-        <option>(select a course)</option>
+        <option disabled selected>(select a course)</option>
         {% for course in courses %}
-            <option data-acronym="{{ course[0] }}"
+            <option data-acronym="{{ course[0] }}" value="{{ course[0] }}"
                 {% unless course[1].cw_exam_ratio %}
                     disabled="disabled"
                 {% endunless %}
@@ -45,11 +45,11 @@ layout: page
     <ul>
         <li>
             <strong>Coursework: </strong>
-            <input id="cw-w8-cw" style="width: 2rem"></input>%
+            <input data-cw-w8="cw" id="cw-w8-cw" style="width: 2rem"></input>%
         </li>
         <li>
             <strong>Exam: </strong>
-            <input id="cw-w8-exam"  style="width: 2rem"></input>%
+            <input data-cw-w8="exam" id="cw-w8-exam"  style="width: 2rem"></input>%
         </li>
     </ul>
     <br>
@@ -57,15 +57,15 @@ layout: page
     <ul>
         <li>
             Exam:
-            <input id="cw-tar-exam"></input>% <button id="cw-lock-exam"></button>
+            <input data-cw-tar="exam" id="cw-tar-exam"></input>% <button data-cw-lock="exam" id="cw-lock-exam"></button>
         </li>
         <li>
             Coursework:
-            <input id="cw-tar-cw"></input>% <button id="cw-lock-cw"></button>
+            <input data-cw-tar="cw" id="cw-tar-cw"></input>% <button data-cw-lock="cw" id="cw-lock-cw"></button>
         </li>
         <li>
             Overall:
-            <input id="cw-tar-all"></input>% <button id="cw-lock-all"></button>
+            <input data-cw-tar="all" id="cw-tar-all"></input>% <button data-cw-lock="all" id="cw-lock-all"></button>
         </li>
     </ul>
     <br>
@@ -77,28 +77,34 @@ layout: page
     </small>
 </p>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script>
 const courseData = {{ courses | jsonify }};
+const getEl = (type, target) => document.querySelector(`[data-cw-${type}="${target}"]`)
 
 function showCalculatorError(str) {
     if (str === "") {
-        $("#ccalc-error").text("");
+        document.querySelector("#ccalc-error").innerText = "";
         return;
     }
 
-    $("#ccalc-error").text("Error: " + str);
+    document.querySelector('#ccalc-error').innerText = `Error: ${str}`
 }
 
 function updateCalculation() {
-    showCalculatorError("");
+    showCalculatorError('');
 
-    const toSolve = "#" + $(lockButtons).filter("button:disabled")[0].id.replace(/lock/g, "tar");
-    console.log("Solving", toSolve)
-    $(toSolve).val("");
+    const toSolve = document.querySelector('[data-cw-tar="' + document.querySelector('[data-cw-lock][disabled]').dataset.cwLock + '"]')
+    console.log("Solving", toSolve.dataset.cwTar)
+    toSolve.value = ''
 
-    var overall = $("#cw-tar-all").val(), exam = $("#cw-tar-exam").val(), cw = $("#cw-tar-cw").val();
-    var ratio_cw = $("#cw-w8-cw").val(), ratio_exam = $("#cw-w8-exam").val();
+
+    let overall = getEl('tar',  'all').value
+    let exam    = getEl('tar', 'exam').value
+    let cw      = getEl('tar',   'cw').value
+
+    let ratio_cw   = getEl('w8',   'cw').value
+    let ratio_exam = getEl('w8', 'exam').value
+
 
     if ((overall != "") && (exam != "") && (cw != "")) {
         showCalculatorError("Only fill two of three targets");
@@ -114,6 +120,7 @@ function updateCalculation() {
         || ((overall == "") && (exam != "") && (cw == ""))
     ) {
         console.log("At least 2 are empty.")
+        showCalculatorError('At least 2 are empty')
         return;
     }
 
@@ -127,7 +134,7 @@ function updateCalculation() {
         cw = parseInt(cw);
     }
 
-    ratio_cw = parseInt(ratio_cw);
+    ratio_cw   = parseInt(ratio_cw);
     ratio_exam = parseInt(ratio_exam);
 
     if (isNaN(ratio_cw) || isNaN(ratio_exam)) {
@@ -143,14 +150,14 @@ function updateCalculation() {
     ratio_cw /= 100;
     ratio_exam /= 100;
 
-    const solveOverall = toSolve === "#cw-tar-all";
-    const solveExam = toSolve === "#cw-tar-exam";
-    const solveCw = toSolve === "#cw-tar-cw";
+    const solveOverall = toSolve.dataset.cwTar === "all";
+    const solveExam    = toSolve.dataset.cwTar === "exam";
+    const solveCw      = toSolve.dataset.cwTar === "cw";
 
     if (solveOverall) {
         // overall = (cw * ratio_cw) + (exam * ratio_exam);
         const result = (cw * ratio_cw) + (exam * ratio_exam);
-        $("#cw-tar-all").val(result);
+        getEl('tar', 'all').value = result
         console.log("#cw-tar-all", result);
     } else if (solveExam || solveCw) {
         // exam = (overall - (cw * ratio_cw)) / ratio_exam
@@ -158,9 +165,8 @@ function updateCalculation() {
         // obj = (overall - inner) / outer
         const inner = solveExam ? (cw * ratio_cw) : (exam * ratio_exam);
         const outer = solveExam ? ratio_exam : ratio_cw;
-        const obj = solveExam ? "#cw-tar-exam" : "#cw-tar-cw";
         const result = (overall - inner) / outer;
-        $(obj).val(result);
+        getEl('tar', solveExam ? 'exam' : 'cw').value = result
         console.log(obj, result);
     } else {
         showCalculatorError("I can't into math.")
@@ -171,50 +177,62 @@ const lockButtons = "#cw-lock-all, #cw-lock-cw, #cw-lock-exam"
 const targetInputs = lockButtons.replace(/lock/g, "tar");
 function handleLock() {
     // Reset everything to normal
-    $(lockButtons).removeAttr('disabled');
-    $(targetInputs).removeAttr('disabled');
-    $(lockButtons).text("calculate me!");
+    document.querySelectorAll('[data-cw-lock]').forEach(el => {
+        el.disabled  = false
+        el.innerText = 'calculate me!'
+    })
+    document.querySelectorAll('[data-cw-tar]').forEach(el => el.disabled = false)
 
-    const input = $("#" + this.id.replace(/lock/g, "tar"));
-    input.val("");
-    input.attr("disabled", true);
 
-    $(this).attr("disabled", true);
-    $(this).text('calculated');
+    const input = document.querySelector(`[data-cw-tar="${this.dataset.cwLock}"]`)
+    input.disabled = true
+    input.value    = ''
+
+    this.disabled = true
+    this.innerText = 'calculated!'
 
     updateCalculation();
 }
 
 function changeCourse() {
-    const acronym = $(this).find("option:selected").data('acronym');
+    const acronym = document.querySelector('#course-list').value
+
     const course = courseData[acronym];
+    const courseEl = document.querySelector('#course-descriptor')
+    console.log('changed course')
     if (!course) {
-        $("#course-descriptor").hide();
+        courseEl.style.display = 'none'
+
         return;
     }
 
-    $("#course-descriptor").show();
-    $("#course-descriptor").attr('href', course.euclid_url);
+    courseEl.style.display = 'block'
+    courseEl.setAttribute('href', course.euclid_url)
 
     if (course.cw_exam_ratio === null) {
         showCalculatorError("course.inf.ed.ac.uk is missing a cw/exam ratio for this course");
         return;
     }
 
-    $("#cw-w8-cw").val(course.cw_exam_ratio[0]);
-    $("#cw-w8-exam").val(course.cw_exam_ratio[1]);
+    getEl('w8', 'cw').value = course.cw_exam_ratio[0]
+    getEl('w8', 'exam').value = course.cw_exam_ratio[1]
 
     updateCalculation();
 }
 
 function loadCourseCalculator() {
-    $("#course-list").change(changeCourse)
+    document.querySelector('#course-list').addEventListener('change', changeCourse)
 
-    $("input").on('input', updateCalculation);
-    $(lockButtons).click(handleLock);
+    document.querySelectorAll('[data-cw-tar]').forEach(el => el.addEventListener('input', updateCalculation))
+    document.querySelectorAll('[data-cw-w8]' ).forEach(el => el.addEventListener('input', updateCalculation))
+    document.querySelectorAll('[data-cw-lock]').forEach(el => el.addEventListener('click', handleLock))
 
-    handleLock.bind($("#cw-lock-all")[0])();
+
+    // fire handler to initially populate the commits
+    try {
+        handleLock()
+    } catch (e) {}
 }
 
-$(loadCourseCalculator);
+window.onload = loadCourseCalculator
 </script>


### PR DESCRIPTION
The only thing untested is the betterinformatics search (on the `_includes/exams.html` block), as the `betterinformatics.com/search` does not have a CORS header and can't be nicely tested on localhost (hence the PR).

Everything else was just migrated using the heuristic:

JQuery | vanilla equivalent
--- | ---
`$` | `document.querySelector` or `document.querySelectorAll`
`.show()` | `.style.display.= 'block'`
`.hide()` | `.style.display.= 'none'`
`.on()` family | `.addEventListener`
`$(func)` | `window.onload`

Additionally, changed `var` to `let`/`const` as appropriate, and used `data-*` attributes.

This should close #77.