### PR TITLE
Update inf2#pwa acronym front-matter (fix #87)

### DIFF
--- a/_sections/inf2/math-pwa.md
+++ b/_sections/inf2/math-pwa.md
@@ -2,7 +2,7 @@
 year: 2
 semester: 2
 title: PWA - Probability with Applications
-acronym: PWA
+course-acronym: PWA
 links:
   - name: piazza
     url: https://piazza.com/ed.ac.uk/spring2018/math08067


### PR DESCRIPTION
Fixed incorrect key of "acronym" to "course-acronym" to make shorturl permalink generation work properly.