### PR TITLE
Add link to Batch Media Hopper Replay Downloader

### DIFF
--- a/_sections/start/useful-links.md
+++ b/_sections/start/useful-links.md
@@ -16,6 +16,7 @@ pinned: true
   - [The Marauders App](https://mapp.betterinformatics.com) - map of machines
   - **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
   - [Exporting Outlook calendar to Webcal / Google calendar](https://medium.com/@neurosnap/how-to-share-outlook-office365s-calendar-with-google-calendar-ca7d9df7c056)
+  - [Batch Downloading Media Hopper Replay lecture recordings](https://tardis.ed.ac.uk/~andrewferguson/echo360/)
 - **Facebook**
   - [School of Informatics](https://facebook.com/groups/informatics.uoe) - for school wide discussion
   - [CompSoc Members](https://facebook.com/groups/compsocedinburgh) - for Informatics related events


### PR DESCRIPTION
Added a link to my script that allows for batch downloading of Media Hopper Replay (Echo360) lecture recordings.

I'm doing this as a PR rather than a direct commit because:
* Hacktoberfest (duh!)
* I'm not sure if Useful Links > Software and Tools is the best place for this. Does it fit here, or would the e-learning section be a better fit?