### PR TITLE
Added info about Echo360 bookmarklet

### DIFF
--- a/_sections/start/useful-links.md
+++ b/_sections/start/useful-links.md
@@ -16,7 +16,7 @@ pinned: true
   - [The Marauders App](https://mapp.betterinformatics.com) - map of machines
   - **Web printing interfaces**: [EveryonePrint](http://www.everyoneprint.is.ed.ac.uk), [ManagePrint](http://www.manageprint.is.ed.ac.uk)
   - [Exporting Outlook calendar to Webcal / Google calendar](https://medium.com/@neurosnap/how-to-share-outlook-office365s-calendar-with-google-calendar-ca7d9df7c056)
-  - [Batch Downloading Media Hopper Replay lecture recordings](https://tardis.ed.ac.uk/~andrewferguson/echo360/)
+  - [Download Media Hopper Replay lecture recordings](https://tardis.ed.ac.uk/~andrewferguson/echo360/) (now with JavaScript bookmarklet for downloading individual lectures (both video and audio) with support for mobile devices)
 - **Facebook**
   - [School of Informatics](https://facebook.com/groups/informatics.uoe) - for school wide discussion
   - [CompSoc Members](https://facebook.com/groups/compsocedinburgh) - for Informatics related events


### PR DESCRIPTION
Another PR from me (my last, as I'll now have enough for Hacktoberfest and so can go back to committing directly to the repo).

This time adding a note that I've now added a bookmarklet to my Echo360 download scripts. You can now download lectures (both audio and video in both standard and high quality) directly in your browser without installing any external dependencies or extensions. It even works on mobile (allowing you to view lectures on your phone so you ~don't need to bother attending in person~ can catch up on revision).

I'll close this some point next week, unless someone wants to close it before then!