### PR TITLE
Remove Facebook group chat link

### DIFF
--- a/_sections/inf2/general.md
+++ b/_sections/inf2/general.md
@@ -9,6 +9,5 @@ links:
     url: https://lists.inf.ed.ac.uk/mailman/private/ug2-students/
 ---
 
-- **[Facebook Group Chat](https://m.me/join/AbZhMMMHfyXwhVsa)**
 - **Honours hurdles**: refer to your [DRPS programme](http://www.drps.ed.ac.uk/)
 - InfBase: a drop in helpdesk for you to get additional tutoring and support with your courses. See the [schedule](https://informaticsstudentsupport.wordpress.com/schedule-at-a-glance/) here - there's no need to sign up, just drop in


### PR DESCRIPTION
...since it no longer works