### PR TITLE
Add new link for normalization tool (IDB)

### DIFF
--- a/_sections/inf3/idb.md
+++ b/_sections/inf3/idb.md
@@ -10,7 +10,7 @@ links:
 _Previously named Database Systems (DBS)_
 
 - Questions and answers from the DBS textbook - [link](http://pages.cs.wisc.edu/~dbbook/openAccess/thirdEdition/solutions/ans3ed-oddonly.pdf)
-- [Normal Form checker (both BCNF and 3NF)](http://raymondcho.net/RelationalDatabaseTools/RelationalDatabaseTools)
+- [Normalization tool](http://www.ict.griffith.edu.au/~jw/normalization/ind.php)
 - [Revision notes by Ben Shaw](https://github.com/benshaaw/revision/tree/master/DBS)
 - [Relational algebra calculator / engine](https://dbis-uibk.github.io/relax/), [example schema definition for tutorial 1](https://gist.github.com/Visgean/8467b0196f9d88be8b2a8da890a7433a)
 - Exam tips:


### PR DESCRIPTION
Old link was dead. The new one does what the old one was supposed to and also additional stuff.