### PR TITLE
Fix footer uwu being broken due to bad merge of query-string removal

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -177,8 +177,9 @@ const App: React.FC = () => {
   // Update local storage if a new uwu query parameter is set
   const [uwu, setLocalUwu] = useLocalStorageState("uwu", false);
   const [searchParams] = useSearchParams();
-  const newUwu = !!searchParams.get("uwu");
-  if (uwu !== newUwu) setLocalUwu(newUwu);
+  const newUwu = searchParams.get("uwu");
+  const newUwuBool = newUwu === "" || newUwu === "true" || newUwu === "1";
+  if (newUwu !== null && newUwuBool !== uwu) setLocalUwu(newUwuBool);
 
   // Retrieve the config options (such as the logo, global menu items, etc) from
   // the global configOptions variable if set (in index.html). The defaults are

--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -34,6 +34,10 @@ const Footer: React.FC<FooterProps> = ({
   const [uwu, setLocalUwu] = useLocalStorageState("uwu", false);
   const setUwu = () => {
     setLocalUwu(!uwu);
+    // Remove any hardcoded uwu query parameter from the URL to avoid confusion
+    const url = new URL(window.location.href);
+    url.searchParams.delete("uwu");
+    window.history.replaceState({}, "", url.toString());
     window.location.reload();
   };
 


### PR DESCRIPTION
In #120 the `query-string` dependency was removed. This required rewriting the logic for the `uwu` query parameter. It turns out that this created buggy behaviour where any newly set uwu value gets overridden when the app is first mounted.

This pull request fixes the bug, and additionally attempts to reduce confusion when a user clicks on `uwu` while already having a URL paramter for it.