### PR TITLE
Show last login date on user profiles if admin

### DIFF
--- a/backend/scoreboard/views.py
+++ b/backend/scoreboard/views.py
@@ -91,9 +91,16 @@ def get_scoreboard_top(scoretype, limit):
 @auth_check.require_login
 def userinfo(request, username):
     user = get_object_or_404(User.objects.select_related("scores"), username=username)
+
+    if auth_check.has_admin_rights(request):
+        last_login = user.last_login
+    else:
+        last_login = None
+
     res = {
         "username": username,
         "displayName": user.profile.display_username,
+        "lastLogin": last_login,
     }
     get_user_scores(user, res)
     return response.success(value=res)

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -265,6 +265,7 @@ export interface NotificationInfo {
 export interface UserInfo {
   username: string;
   displayName: string;
+  lastLogin: string | null; // ISO 8601, last login time
   rank: number;
   total_users: number;
   score: number;

--- a/frontend/src/pages/userinfo-page.tsx
+++ b/frontend/src/pages/userinfo-page.tsx
@@ -1,4 +1,11 @@
-import { Container, Alert, Tabs, LoadingOverlay, Space } from "@mantine/core";
+import {
+  Container,
+  Alert,
+  Tabs,
+  LoadingOverlay,
+  Space,
+  Text,
+} from "@mantine/core";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useUserInfo } from "../api/hooks";
@@ -18,8 +25,7 @@ const UserPage: React.FC = () => {
   const { username = user.username } = useParams() as { username?: string };
   useTitle(username);
   const isMyself = user.username === username;
-  const [error, loading, userInfo, reloadUserInfo] =
-    useUserInfo(username);
+  const [error, loading, userInfo, reloadUserInfo] = useUserInfo(username);
   const [activeTab, setActiveTab] = useState<string | null>("overview");
 
   // Assume any error is because of 404
@@ -54,6 +60,11 @@ const UserPage: React.FC = () => {
               <Alert color="gray">There's nothing here</Alert>
             )}
             {isMyself && <UserNotifications />}
+            {user.isAdmin && userInfo?.lastLogin && (
+              <Text mb="md" c="dimmed" size="xs">
+                Last login: {new Date(userInfo.lastLogin).toLocaleString()}
+              </Text>
+            )}
           </Tabs.Panel>
           <Tabs.Panel value="answers" pt="sm">
             <UserAnswers username={username} />


### PR DESCRIPTION
This PR implements a helpful admin feature to check the last login date of a user. This is particularly useful in order to have an accurate assessment of current student users vs those who have graduated away.

<img width="590" height="331" alt="msedge_2026-08-17_00-24-58" src="https://github.com/user-attachments/assets/c0f31e8f-90bd-4855-87f3-8548a3b813a5" />
