### PR TITLE
Cool bitmask bar instead of badges for exam progress

### DIFF
--- a/backend/categories/migrations/0020_examcounts_add_bitmask.py
+++ b/backend/categories/migrations/0020_examcounts_add_bitmask.py
@@ -1,0 +1,56 @@
+# Manually written on 2026/08/17
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("categories", "0019_coursestats_course_organiser"),
+    ]
+
+    # Adds answered_bits: it is a binary string (NOT a bitstring) of ordered
+    # answer sections with answers (1) or not (0)
+    sql = """
+    CREATE OR REPLACE VIEW categories_examcounts (id, exam_id, count_cuts, count_answered, answered_bits) AS
+        SELECT
+            CAST(ae.id AS bigint),
+            ae.id,
+            COUNT(aas.id) FILTER (WHERE aas.has_answers),
+            COUNT(sub.answer_section_id),
+            (
+                SELECT COALESCE(string_agg(
+                    CASE WHEN EXISTS (
+                        SELECT 1 FROM answers_answer aa WHERE aa.answer_section_id = aas2.id
+                    ) THEN '1' ELSE '0' END,
+                    ''
+                    ORDER BY aas2.page_num, aas2.rel_height
+                ), '')
+                FROM answers_answersection aas2
+                WHERE aas2.exam_id = ae.id AND aas2.has_answers
+            )
+        FROM answers_exam ae
+        LEFT JOIN answers_answersection aas ON aas.exam_id = ae.id
+        LEFT JOIN (
+            SELECT answer_section_id
+            FROM answers_answer aa
+            GROUP BY aa.answer_section_id
+        ) sub ON sub.answer_section_id = aas.id
+        GROUP BY ae.id
+    ;
+    """
+
+    reverse_sql = """
+    CREATE OR REPLACE VIEW categories_examcounts (id, exam_id, count_cuts, count_answered) AS
+        SELECT CAST(ae.id AS bigint), ae.id, COUNT(aas.id) FILTER (WHERE aas.has_answers), COUNT(sub.answer_section_id)
+        FROM answers_exam ae
+        LEFT JOIN answers_answersection aas ON aas.exam_id = ae.id
+        LEFT JOIN (
+            SELECT answer_section_id
+            FROM answers_answer aa
+            GROUP BY aa.answer_section_id
+        ) sub ON sub.answer_section_id = aas.id
+        GROUP BY ae.id
+    ;
+    """
+
+    operations = [migrations.RunSQL(sql, reverse_sql)]

--- a/backend/categories/models.py
+++ b/backend/categories/models.py
@@ -70,6 +70,7 @@ class ExamCounts(models.Model):
 
     count_cuts = models.IntegerField()
     count_answered = models.IntegerField()
+    answered_bits = models.TextField(null=True)
 
     class Meta:
         managed = False

--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -151,6 +151,7 @@ def list_exams(request, slug):
                 "canView": ex.current_user_can_view(request),
                 "count_cuts": ex.counts.count_cuts,
                 "count_answered": ex.counts.count_answered,
+                "answered_bits": ex.counts.answered_bits,
                 "user_solved": ex.user_solved,
             }
             for ex in exams

--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -71,4 +71,8 @@
     width: 100%;
     height: 100%;
   }
+
+  & :not(a) {
+    z-index: 1;
+  }
 }

--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -25,6 +25,17 @@
       var(--mantine-color-gray-3);
   }
 
+  & .answered-bar {
+    @mixin smaller-than $mantine-breakpoint-sm {
+      display: none;
+    }
+  }
+
+  & .answered-count {
+    text-align: right;
+    opacity: 0.8;
+  }
+
   & > :first-child {
     /* Align inner content with how it should be without the exam-table
     negative margin */
@@ -45,6 +56,10 @@
 
   &:hover {
     background-color: var(--mantine-color-gray-light);
+
+    & .answered-count {
+      opacity: 1;
+    }
   }
 
   @mixin dark {

--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -5,6 +5,10 @@
 }
 
 .exam-table {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  column-gap: var(--mantine-spacing-sm);
+
   /* Appear flush with the outer edge of Paper. Use the same breakpoints. */
   width: calc(100% + 2 * var(--mantine-spacing-sm));
   margin-left: calc(-1 * var(--mantine-spacing-sm));
@@ -16,6 +20,10 @@
 }
 
 .exam-row {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+
   border-bottom: calc(0.0625rem * var(--mantine-scale)) solid
     var(--mantine-color-gray-3);
   padding: calc(var(--mantine-spacing-xs) / 2) 0;
@@ -26,14 +34,11 @@
   }
 
   & .answered-bar {
+    /* Hide on smaller screens, as this element isn't part of the link and
+    we don't want to steal screen space. */
     @mixin smaller-than $mantine-breakpoint-sm {
       display: none;
     }
-  }
-
-  & .answered-count {
-    text-align: right;
-    opacity: 0.8;
   }
 
   & > :first-child {
@@ -56,10 +61,6 @@
 
   &:hover {
     background-color: var(--mantine-color-gray-light);
-
-    & .answered-count {
-      opacity: 1;
-    }
   }
 
   @mixin dark {
@@ -78,6 +79,7 @@
     text-decoration: none;
   }
 
+  /* Make the entire row clickable by expanding the a element larger */
   & a::before {
     content: "";
     position: absolute;
@@ -87,6 +89,7 @@
     height: 100%;
   }
 
+  /* Make content in the row (e.g. official solutions) go above the link */
   & :not(a) {
     z-index: 1;
   }

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -23,6 +23,7 @@ import { clsx } from "clsx";
 import {
   IconChecklist,
   IconEyeOff,
+  IconFileCertificate,
   IconPencilCheck,
   IconScissors,
   IconTrash,
@@ -148,13 +149,22 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
               flex="0 0 auto"
             />
             <Stack gap={0} flex={1} className={clsx(examTypeClasses.examLink)}>
-              {exam.canView ? (
-                <Anchor component={Link} to={`/exams/${exam.filename}`}>
-                  <Text size="md">{exam.displayname}</Text>
-                </Anchor>
-              ) : (
-                exam.displayname
-              )}
+              <Group gap="xs">
+                {exam.canView ? (
+                  <Anchor component={Link} to={`/exams/${exam.filename}`}>
+                    <Text size="md">{exam.displayname}</Text>
+                  </Anchor>
+                ) : (
+                  exam.displayname
+                )}
+                {exam.has_solution && (
+                  <StatusIcon
+                    tooltip="Official Solutions Available"
+                    icon={IconFileCertificate}
+                    color="blue"
+                  />
+                )}
+              </Group>
               {exam.remark && (
                 <Text c="dimmed" size="sm" mb="0.15em">
                   {exam.remark}
@@ -162,15 +172,6 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
               )}
             </Stack>
             <Group gap={4} wrap="nowrap">
-              {exam.has_solution && (
-                <Badge
-                  className={examTypeClasses.badge}
-                  title="Has an official solution."
-                  color="green"
-                >
-                  Solution
-                </Badge>
-              )}
               <Tooltip
                 label={`There are ${exam.count_cuts} questions, of which ${exam.count_answered} have at least one solution.`}
               >

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -173,9 +173,13 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
             </Stack>
             <Group gap={4} wrap="nowrap">
               <Tooltip
-                label={`${exam.count_answered}/${exam.count_cuts} questions have an answer.`}
+                label={`${exam.count_answered}/${exam.count_cuts} questions have been answered.`}
               >
                 <svg width="100" height="25" xmlns="http://www.w3.org/2000/svg">
+                  <title>
+                    {exam.count_answered} out of {exam.count_cuts} questions
+                    have been answered.
+                  </title>
                   <rect
                     x="0"
                     y="0"

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -173,7 +173,7 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
             </Stack>
             <Group gap={4} wrap="nowrap">
               <Tooltip
-                label={`There are ${exam.count_cuts} questions, of which ${exam.count_answered} have at least one solution.`}
+                label={`${exam.count_answered}/${exam.count_cuts} questions have an answer.`}
               >
                 <svg width="100" height="25" xmlns="http://www.w3.org/2000/svg">
                   <rect

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -1,7 +1,6 @@
 import { useRequest } from "ahooks";
 import {
   Anchor,
-  Badge,
   Box,
   Checkbox,
   Group,
@@ -128,12 +127,9 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
       </Group>
       <Box className={examTypeClasses.examTable}>
         {exams.map(exam => (
-          <Group
+          <Box
             key={exam.filename}
             className={clsx(examTypeClasses.examRow, fadeClasses.fadeInOrder)}
-            align="center"
-            wrap="nowrap"
-            gap="md"
           >
             <Checkbox
               checked={selected.has(exam.filename)}
@@ -146,9 +142,9 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
               // Might be obsolete code below, unviewable exams should be
               // filtered already at this point.
               disabled={!exam.canView}
-              flex="0 0 auto"
+              style={{ alignSelf: "center" }}
             />
-            <Stack gap={0} flex={1} className={clsx(examTypeClasses.examLink)}>
+            <Stack gap={0} className={clsx(examTypeClasses.examLink)}>
               <Group gap="xs">
                 {exam.canView ? (
                   <Anchor component={Link} to={`/exams/${exam.filename}`}>
@@ -218,11 +214,7 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                     fill="transparent"
                   />
                 </svg>
-                <Text
-                  aria-hidden
-                  size="sm"
-                  className={examTypeClasses.answeredCount}
-                >
+                <Text aria-hidden size="sm" opacity={0.8}>
                   {exam.count_answered}/{exam.count_cuts}
                 </Text>
               </Group>
@@ -278,7 +270,7 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                 />
               )}
             </Group>
-          </Group>
+          </Box>
         ))}
       </Box>
     </>

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -171,15 +171,24 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                 </Text>
               )}
             </Stack>
-            <Group gap={4} wrap="nowrap">
-              <Tooltip
-                label={`${exam.count_answered}/${exam.count_cuts} questions have been answered.`}
+            <Tooltip
+              label={`${exam.count_answered}/${exam.count_cuts} questions have been answered.`}
+            >
+              <Group
+                gap={4}
+                wrap="nowrap"
+                pos="relative"
+                justify="space-between"
               >
-                <svg width="100" height="25" xmlns="http://www.w3.org/2000/svg">
-                  <title>
-                    {exam.count_answered} out of {exam.count_cuts} questions
-                    have been answered.
-                  </title>
+                <svg
+                  width="100"
+                  height="25"
+                  xmlns="http://www.w3.org/2000/svg"
+                  role="img"
+                  aria-label={`${exam.count_answered} out of ${exam.count_cuts} questions have
+                    been answered.`}
+                  className={examTypeClasses.answeredBar}
+                >
                   <rect
                     x="0"
                     y="0"
@@ -209,8 +218,15 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                     fill="transparent"
                   />
                 </svg>
-              </Tooltip>
-            </Group>
+                <Text
+                  aria-hidden
+                  size="sm"
+                  className={examTypeClasses.answeredCount}
+                >
+                  {exam.count_answered}/{exam.count_cuts}
+                </Text>
+              </Group>
+            </Tooltip>
             {catAdmin && !exam.finished_cuts && (
               <ClaimButton exam={exam} reloadExams={reload} size="compact-sm" />
             )}

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
 } from "@mantine/core";
 import React from "react";
 import examTypeClasses from "./exam-type-section.module.css";
@@ -95,6 +96,24 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
     reload();
   }
 
+  const contiguousAnswered = (exam: CategoryExam) => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+    return [...exam.answered_bits, "1"].reduce<
+      { bit: string; count: number; index: number }[]
+    >((acc, b, index) => {
+      if (acc.length === 0) {
+        return [{ bit: b, count: 1, index }];
+      }
+      if (b === acc[acc.length - 1].bit) {
+        acc[acc.length - 1].count += 1;
+        return acc;
+      } else {
+        acc.push({ bit: b, count: 1, index });
+        return acc;
+      }
+    }, []);
+  };
+
   return (
     <>
       {modals}
@@ -143,12 +162,6 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
               )}
             </Stack>
             <Group gap={4} wrap="nowrap">
-              <Badge
-                className={examTypeClasses.badge}
-                title={`There are ${exam.count_cuts} questions, of which ${exam.count_answered} have at least one solution.`}
-              >
-                {exam.count_answered} / {exam.count_cuts}
-              </Badge>
               {exam.has_solution && (
                 <Badge
                   className={examTypeClasses.badge}
@@ -158,6 +171,40 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                   Solution
                 </Badge>
               )}
+              <Tooltip
+                label={`There are ${exam.count_cuts} questions, of which ${exam.count_answered} have at least one solution.`}
+              >
+                <svg width="100" height="25" xmlns="http://www.w3.org/2000/svg">
+                  <rect
+                    x="0"
+                    y="0"
+                    width="100"
+                    height="10"
+                    fill="transparent"
+                  />
+                  {contiguousAnswered(exam).map(({ bit, count, index }) => (
+                    <rect
+                      x={((index * 100) / exam.answered_bits.length).toFixed(2)}
+                      y="10"
+                      width={(count * 100) / exam.answered_bits.length}
+                      height="5"
+                      fill={
+                        bit === "1"
+                          ? "var(--mantine-primary-color-filled)"
+                          : "transparent"
+                      }
+                      key={index}
+                    />
+                  ))}
+                  <rect
+                    x="0"
+                    y="15"
+                    width="100"
+                    height="10"
+                    fill="transparent"
+                  />
+                </svg>
+              </Tooltip>
             </Group>
             {catAdmin && !exam.finished_cuts && (
               <ClaimButton exam={exam} reloadExams={reload} size="compact-sm" />

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -192,7 +192,7 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                       fill={
                         bit === "1"
                           ? "var(--mantine-primary-color-filled)"
-                          : "transparent"
+                          : "var(--mantine-primary-color-light)"
                       }
                       key={index}
                     />

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -146,6 +146,7 @@ export interface CategoryExam {
   canView: boolean; // whether the exam can be viewed by the user
   count_cuts: number; // number of cuts in exam
   count_answered: number; // number of cuts with answers in exam
+  answered_bits: string; // which cuts have answers
   user_solved: boolean;
 }
 


### PR DESCRIPTION
The more that an exam has crowdsourced answers, the more useful it is for studies. Currently, we show the statistic for exams as a numerical badge (e.g. "20/40" for 20 answers for 40 questions). While this is somewhat useful, in my opinion it doesn't visually convey *how* useful, unless you do mental maths yourself. 

In this pull request I propose a "bitmask bar" for exams, which is like a progress bar but shows a segment for each answer section and colors in those.

<img width="429" height="114" alt="msedge_2026-08-17_22-26-08" src="https://github.com/user-attachments/assets/cffb7af9-e14e-49f9-a1c0-6894beb1ce54" />

In the above example of the bitmask bar, we can see that there is an unanswered question in the beginning, a large block of answered questions, and a small segment of answered questions further down. I believe this is more useful than a badge, or even a progress bar.

## Screenshots

<table>
<tr>
 <td>Before
 <td>
<img width="903" height="781" alt="image" src="https://github.com/user-attachments/assets/a8ad5f84-b313-447b-bd74-f4499d7e730f" />
<tr>
 <td>After
 <td><img width="913" height="737" alt="msedge_2026-08-18_00-21-09" src="https://github.com/user-attachments/assets/5df35a3f-b836-440b-b3d9-91ab1391207f" />
</table>

## Implementation

In order to compute this bitmask most efficiently, it is done at the database layer. The Postgres view for exam statistics has been modified to calculate the string of 0s/1s (e.g. 11001 for 5 sections, 3 of which are answered). The Python layer just transparently sends this string over to the frontend. The frontend then manually crafts (very simple) svgs, consisting of `rect`s either colored dark or light. I first tried using a `rect` for each section (e.g 5 rects for 11001), but this created visible borders between the segments. As such, I precalculate and merge the consecutive spans to produce the minimal rects (e.g. 3 rects for 11001).

## Accessibility

As we are removing a text element from the UI, I've made sure to compensate on the accessibility-front by adding screen reader support to the SVGs. Verified on my local browser that it reads out the svg next to exams properly.