### PR TITLE
Fix claim button changing exam list layout above 4 columns

### DIFF
--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -6,7 +6,7 @@
 
 .exam-table {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto 1fr auto auto auto;
   column-gap: var(--mantine-spacing-sm);
 
   /* Appear flush with the outer edge of Paper. Use the same breakpoints. */

--- a/frontend/src/components/exam-type-section.tsx
+++ b/frontend/src/components/exam-type-section.tsx
@@ -167,6 +167,11 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                 </Text>
               )}
             </Stack>
+            {catAdmin && !exam.finished_cuts ? (
+              <ClaimButton exam={exam} reloadExams={reload} size="compact-sm" />
+            ) : (
+              <div />
+            )}
             <Tooltip
               label={`${exam.count_answered}/${exam.count_cuts} questions have been answered.`}
             >
@@ -219,9 +224,6 @@ const ExamTypeSection: React.FC<ExamTypeCardProps> = ({
                 </Text>
               </Group>
             </Tooltip>
-            {catAdmin && !exam.finished_cuts && (
-              <ClaimButton exam={exam} reloadExams={reload} size="compact-sm" />
-            )}
             <Group gap="xs" wrap="nowrap">
               <IconButton
                 size="sm"


### PR DESCRIPTION
The change introduced in #126 failed to account for the Claim Button that admins see. The button increases each row to have 5 elements instead of 4, causing broken layout. This PR fixes the issue by always using 5 columns (in the CSS grid definition) and adding an empty div when there is no claim button to be shown.