### PR TITLE
Fix the link hitbox in the exam list being thinner than row

### DIFF
--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -59,6 +59,10 @@
   }
 
   &:hover {
+    background-color: var(--mantine-color-gray-light-hover);
+  }
+
+  &:active {
     background-color: var(--mantine-color-gray-light);
   }
 

--- a/frontend/src/components/exam-type-section.module.css
+++ b/frontend/src/components/exam-type-section.module.css
@@ -26,7 +26,6 @@
 
   border-bottom: calc(0.0625rem * var(--mantine-scale)) solid
     var(--mantine-color-gray-3);
-  padding: calc(var(--mantine-spacing-xs) / 2) 0;
 
   &:first-child {
     border-top: calc(0.0625rem * var(--mantine-scale)) solid
@@ -74,6 +73,7 @@
 
 .exam-link {
   position: relative;
+  padding: calc(var(--mantine-spacing-xs) / 2) 0;
 
   & a:hover {
     text-decoration: none;


### PR DESCRIPTION
Best communicated visually:

<table>
<tr>
 <td>Before
 <td>
<img width="773" height="170" alt="msedge_2026-08-18_20-58-46" src="https://github.com/user-attachments/assets/f136fe9f-81be-4e96-bb9a-cb7fce729d60" />

<tr>
 <td>After
 <td>
<img width="716" height="169" alt="msedge_2026-08-18_20-58-55" src="https://github.com/user-attachments/assets/dad402b2-2b2c-42c3-b419-84b93b397233" />

</table>

Additionally, `:active` styling has been added for exam list rows: this should help mobile users mostly, but also for anyone who needs visual feedback upon clicking.