### PR TITLE
Add merge_group to CI to trigger on merge trains

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
+  merge_group:
+    types: [ checks_requested ]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This PR adds a trigger for CI on the `merge_group` event, so we can experiment around with the new GitHub merge trains/queue feature. 