### PR TITLE
Fix fullscreen editor, use monospace fonts

### DIFF
--- a/frontend/src/components/Editor/BasicEditor.module.css
+++ b/frontend/src/components/Editor/BasicEditor.module.css
@@ -3,6 +3,8 @@
 }
 
 .common {
+  font-family: "Fira Code", monospace;
+  font-size: 0.875rem;
   white-space: pre-wrap;
   word-wrap: break-word;
   width: 100%;

--- a/frontend/src/components/Editor/Editor.module.css
+++ b/frontend/src/components/Editor/Editor.module.css
@@ -2,7 +2,7 @@
   padding: 1.2em;
 }
 
-.fullScreen {
+.fullscreen {
   flex-grow: 1;
 }
 
@@ -35,13 +35,16 @@
 }
 
 .shadowOnFocus {
-  transition: linear 100ms box-shadow, linear 50ms outline-width;
+  transition:
+    linear 100ms box-shadow,
+    linear 50ms outline-width;
   outline-width: 0;
   outline-style: solid;
   outline-color: var(--mantine-primary-color-filled);
   outline-offset: 2px;
 
-  &:hover, &:focus-within {
+  &:hover,
+  &:focus-within {
     box-shadow: var(--mantine-shadow-xs);
   }
 
@@ -49,7 +52,6 @@
     outline-width: 2px;
   }
 }
-
 
 .borderStyle {
   border-width: 0.1em;


### PR DESCRIPTION
This PR implements two minor bugfixes to the Editor component:
- Revert to monospace fonts (since this is easier to write Markdown in) after being changed in 9c5302e64d49fdaec03ddf0547eceab585fa7093
- Fix fullscreen after being broken by 0758dd34bcf43e500e385b23adbf042e9f2f9331 