### PR TITLE
Show community documents as list instead of grid

### DIFF
--- a/frontend/src/components/document-list.tsx
+++ b/frontend/src/components/document-list.tsx
@@ -6,10 +6,8 @@ import {
   Title,
   useComputedColorScheme,
 } from "@mantine/core";
-import React, { Fragment, useMemo } from "react";
+import React, { useMemo } from "react";
 import CreateDocumentForm from "./create-document-modal";
-import Grid from "./grid";
-import DocumentCard from "./document-card";
 import { IconPlus } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
 import ShimmerButton from "./shimmer-button";
@@ -98,6 +96,7 @@ const DocumentList: React.FC<Props> = ({ slug }) => {
                 key={type}
                 type={type === "Documents" ? null : type}
                 documents={splitDocs[type]}
+                refetch={() => void documents.refetch()}
               />
             ),
         )}

--- a/frontend/src/components/document-list.tsx
+++ b/frontend/src/components/document-list.tsx
@@ -16,6 +16,7 @@ import ShimmerButton from "./shimmer-button";
 import { useListDocuments, useListDocumentTypes } from "../api/hooks/documents";
 import type { DocumentListSchema } from "../api/model/documentListSchema";
 import type { DocumentSchema } from "../api/model/documentSchema";
+import { DocumentTypeSection } from "./document-type-section";
 
 interface Props {
   slug: string;
@@ -93,27 +94,21 @@ const DocumentList: React.FC<Props> = ({ slug }) => {
         docTypes.data.value.map(
           type =>
             splitDocs?.[type] && (
-              <Fragment key={type}>
-                {type !== "Documents" && (
-                  <Title order={3} mt="xl" mb="lg">
-                    {type}
-                  </Title>
-                )}
-                <Grid>
-                  {splitDocs[type].map(document => (
-                    <DocumentCard key={document.slug} document={document} />
-                  ))}
-                </Grid>
-              </Fragment>
+              <DocumentTypeSection
+                key={type}
+                type={type === "Documents" ? null : type}
+                documents={splitDocs[type]}
+              />
             ),
         )}
-      {splitDocs && Object.values(splitDocs).every(docs => docs.length === 0) && (
-        <Alert variant="light" color="compsocMain">
-          No community documents yet. Upload your own to share! Cheatsheets,
-          study notes, code implementations of algorithms, Anki decks, and more
-          are all welcome.
-        </Alert>
-      )}
+      {splitDocs &&
+        Object.values(splitDocs).every(docs => docs.length === 0) && (
+          <Alert variant="light" color="compsocMain">
+            No community documents yet. Upload your own to share! Cheatsheets,
+            study notes, code implementations of algorithms, Anki decks, and
+            more are all welcome.
+          </Alert>
+        )}
     </>
   );
 };

--- a/frontend/src/components/document-type-section.module.css
+++ b/frontend/src/components/document-type-section.module.css
@@ -1,0 +1,81 @@
+.document-table {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  column-gap: var(--mantine-spacing-sm);
+
+  /* Appear flush with the outer edge of Paper. Use the same breakpoints. */
+  width: calc(100% + 2 * var(--mantine-spacing-sm));
+  margin-left: calc(-1 * var(--mantine-spacing-sm));
+
+  @mixin larger-than $mantine-breakpoint-sm {
+    width: calc(100% + 2 * var(--mantine-spacing-md));
+    margin-left: calc(-1 * var(--mantine-spacing-md));
+  }
+}
+
+.document-row {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: center;
+
+  border-bottom: calc(0.0625rem * var(--mantine-scale)) solid
+    var(--mantine-color-gray-3);
+
+  &:first-child {
+    border-top: calc(0.0625rem * var(--mantine-scale)) solid
+      var(--mantine-color-gray-3);
+  }
+
+  & > :first-child {
+    /* Align inner content with how it should be without the exam-table
+    negative margin */
+    padding-left: var(--mantine-spacing-sm);
+
+    @mixin larger-than $mantine-breakpoint-sm {
+      padding-left: var(--mantine-spacing-md);
+    }
+  }
+
+  & > :last-child {
+    padding-right: var(--mantine-spacing-sm);
+
+    @mixin larger-than $mantine-breakpoint-sm {
+      padding-right: var(--mantine-spacing-md);
+    }
+  }
+
+  &:hover {
+    background-color: var(--mantine-color-gray-light-hover);
+  }
+
+  &:active {
+    background-color: var(--mantine-color-gray-light);
+  }
+
+  @mixin dark {
+    border-bottom-color: var(--mantine-color-dark-4);
+
+    &:first-child {
+      border-top-color: var(--mantine-color-dark-4);
+    }
+  }
+}
+
+.document-link {
+  padding: calc(var(--mantine-spacing-xs) / 2) 0;
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  /* Make the entire row clickable by expanding the a element larger */
+  & a::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/frontend/src/components/document-type-section.module.css
+++ b/frontend/src/components/document-type-section.module.css
@@ -1,6 +1,6 @@
 .document-table {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto auto;
   column-gap: var(--mantine-spacing-sm);
 
   /* Appear flush with the outer edge of Paper. Use the same breakpoints. */
@@ -63,9 +63,10 @@
 }
 
 .document-link {
+  position: relative;
   padding: calc(var(--mantine-spacing-xs) / 2) 0;
 
-  &:hover {
+  & a:hover {
     text-decoration: none;
   }
 

--- a/frontend/src/components/document-type-section.tsx
+++ b/frontend/src/components/document-type-section.tsx
@@ -5,7 +5,6 @@ import {
   Title,
   Text,
   Anchor,
-  Stack,
   Group,
   Button,
   Tooltip,
@@ -44,16 +43,16 @@ export const DocumentTypeSection: React.FC<{
               fadeClasses.fadeInOrder,
             )}
           >
-            <Stack gap={0} className={documentTypeClasses.documentLink}>
+            <Group gap="xs" className={documentTypeClasses.documentLink}>
               <Anchor component={Link} to={`/document/${document.slug}`}>
                 <Text size="md">{document.display_name}</Text>
               </Anchor>
               <Text c="dimmed">
                 {document.anonymised
-                  ? "Anonymous"
-                  : `@${document.author.username}`}
+                  ? "(Anonymous)"
+                  : `(@${document.author.username})`}
               </Text>
-            </Stack>
+            </Group>
             {document.edittime ? (
               <Text c="dimmed" component="span" size="xs" ta="right">
                 Last updated {formatDistanceToNow(new Date(document.edittime))}{" "}

--- a/frontend/src/components/document-type-section.tsx
+++ b/frontend/src/components/document-type-section.tsx
@@ -1,17 +1,33 @@
 import React from "react";
 import { DocumentSchema } from "../api/model";
-import { Box, Title, Text, Anchor, Flex, Stack } from "@mantine/core";
+import {
+  Box,
+  Title,
+  Text,
+  Anchor,
+  Stack,
+  Group,
+  Button,
+  Tooltip,
+} from "@mantine/core";
 import documentTypeClasses from "./document-type-section.module.css";
 import fadeClasses from "../utils/fade-in-order.module.css";
 import { clsx } from "clsx";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { Link } from "react-router-dom";
 import { IconHeart, IconHeartFilled } from "@tabler/icons-react";
+import { useUpdateDocument } from "../api/hooks/documents";
 
 export const DocumentTypeSection: React.FC<{
   type: string | null;
   documents: readonly DocumentSchema[];
-}> = ({ type, documents }) => {
+  refetch: () => void;
+}> = ({ type, documents, refetch }) => {
+  const { mutate: likeDocument } = useUpdateDocument({
+    mutation: {
+      onSuccess: refetch,
+    },
+  });
   return (
     <>
       {type && (
@@ -46,21 +62,33 @@ export const DocumentTypeSection: React.FC<{
             ) : (
               <div />
             )}
-            {document.liked ? (
-              <Flex align="center" color="red">
-                <IconHeartFilled color="red" />
-                <Text fw={700} c="red" ml="0.3em">
-                  {document.like_count}
-                </Text>
-              </Flex>
-            ) : (
-              <Flex align="center">
-                <IconHeart />
-                <Text fw={700} ml="0.3em">
-                  {document.like_count}
-                </Text>
-              </Flex>
-            )}
+            <Tooltip
+              label={document.liked ? "Remove your mark" : "Mark as liked"}
+            >
+              <Button
+                variant="transparent"
+                c={
+                  document.liked
+                    ? "var(--mantine-color-red-filled)"
+                    : "currentcolor"
+                }
+                onClick={() =>
+                  likeDocument({
+                    slug: document.slug,
+                    data: {
+                      liked: !document.liked,
+                    },
+                  })
+                }
+                justify="flex-end"
+                pl={0}
+              >
+                <Group gap="xs" wrap="nowrap">
+                  {document.like_count?.toString()}
+                  {document.liked ? <IconHeartFilled /> : <IconHeart />}
+                </Group>
+              </Button>
+            </Tooltip>
           </Box>
         ))}
       </Box>

--- a/frontend/src/components/document-type-section.tsx
+++ b/frontend/src/components/document-type-section.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DocumentSchema } from "../api/model";
-import { Box, Title, Text, Anchor, Flex } from "@mantine/core";
+import { Box, Title, Text, Anchor, Flex, Stack } from "@mantine/core";
 import documentTypeClasses from "./document-type-section.module.css";
 import fadeClasses from "../utils/fade-in-order.module.css";
 import { clsx } from "clsx";
@@ -28,31 +28,23 @@ export const DocumentTypeSection: React.FC<{
               fadeClasses.fadeInOrder,
             )}
           >
-            <Anchor
-              component={Link}
-              to={`/document/${document.slug}`}
-              className={documentTypeClasses.documentLink}
-            >
-              <Text size="md">{document.display_name}</Text>
-            </Anchor>
+            <Stack gap={0} className={documentTypeClasses.documentLink}>
+              <Anchor component={Link} to={`/document/${document.slug}`}>
+                <Text size="md">{document.display_name}</Text>
+              </Anchor>
+              <Text c="dimmed">
+                {document.anonymised
+                  ? "Anonymous"
+                  : `@${document.author.username}`}
+              </Text>
+            </Stack>
             {document.edittime ? (
-              <Text c="dimmed" component="span" size="xs">
+              <Text c="dimmed" component="span" size="xs" ta="right">
                 Last updated {formatDistanceToNow(new Date(document.edittime))}{" "}
                 ago
               </Text>
             ) : (
               <div />
-            )}
-            {document.anonymised ? (
-              <Text c="dimmed">Anonymous</Text>
-            ) : (
-              <Anchor
-                component={Link}
-                to={`/user/${document.author.username}`}
-                c="dimmed"
-              >
-                @{document.author.username}
-              </Anchor>
             )}
             {document.liked ? (
               <Flex align="center" color="red">

--- a/frontend/src/components/document-type-section.tsx
+++ b/frontend/src/components/document-type-section.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { DocumentSchema } from "../api/model";
+import { Box, Title, Text, Anchor, Flex } from "@mantine/core";
+import documentTypeClasses from "./document-type-section.module.css";
+import fadeClasses from "../utils/fade-in-order.module.css";
+import { clsx } from "clsx";
+import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
+import { Link } from "react-router-dom";
+import { IconHeart, IconHeartFilled } from "@tabler/icons-react";
+
+export const DocumentTypeSection: React.FC<{
+  type: string | null;
+  documents: readonly DocumentSchema[];
+}> = ({ type, documents }) => {
+  return (
+    <>
+      {type && (
+        <Title order={3} mt="xl" mb="lg">
+          {type}
+        </Title>
+      )}
+      <Box className={documentTypeClasses.documentTable}>
+        {documents.map(document => (
+          <Box
+            key={document.slug}
+            className={clsx(
+              documentTypeClasses.documentRow,
+              fadeClasses.fadeInOrder,
+            )}
+          >
+            <Anchor
+              component={Link}
+              to={`/document/${document.slug}`}
+              className={documentTypeClasses.documentLink}
+            >
+              <Text size="md">{document.display_name}</Text>
+            </Anchor>
+            {document.edittime ? (
+              <Text c="dimmed" component="span" size="xs">
+                Last updated {formatDistanceToNow(new Date(document.edittime))}{" "}
+                ago
+              </Text>
+            ) : (
+              <div />
+            )}
+            {document.anonymised ? (
+              <Text c="dimmed">Anonymous</Text>
+            ) : (
+              <Anchor
+                component={Link}
+                to={`/user/${document.author.username}`}
+                c="dimmed"
+              >
+                @{document.author.username}
+              </Anchor>
+            )}
+            {document.liked ? (
+              <Flex align="center" color="red">
+                <IconHeartFilled color="red" />
+                <Text fw={700} c="red" ml="0.3em">
+                  {document.like_count}
+                </Text>
+              </Flex>
+            ) : (
+              <Flex align="center">
+                <IconHeart />
+                <Text fw={700} ml="0.3em">
+                  {document.like_count}
+                </Text>
+              </Flex>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+};

--- a/frontend/src/components/document-type-section.tsx
+++ b/frontend/src/components/document-type-section.tsx
@@ -54,7 +54,13 @@ export const DocumentTypeSection: React.FC<{
               </Text>
             </Group>
             {document.edittime ? (
-              <Text c="dimmed" component="span" size="xs" ta="right">
+              <Text
+                c="dimmed"
+                component="span"
+                size="xs"
+                ta="right"
+                display={{ base: "none", sm: "block" }}
+              >
                 Last updated {formatDistanceToNow(new Date(document.edittime))}{" "}
                 ago
               </Text>


### PR DESCRIPTION
Similar to #126 but for community documents:

<table>
<tr>
 <td>Before
 <td><img width="905" height="337" alt="msedge_2026-08-19_14-34-46" src="https://github.com/user-attachments/assets/556e57f3-0637-4e40-9825-94ddf03fedbd" />
<tr>
 <td>After
 <td><img width="942" height="199" alt="msedge_2026-08-19_14-34-27" src="https://github.com/user-attachments/assets/9c46d5cb-f9cf-4445-8843-25b0d2f22a45" />

</table>


Additionally, the heart icon is now a clickable button that triggers a mutation, whereas previously it was just static.