### PR TITLE
Fix ExtremelyTrustedHTML breaking when no script tags exist

### DIFF
--- a/frontend/src/components/extremely-trusted-html.tsx
+++ b/frontend/src/components/extremely-trusted-html.tsx
@@ -69,6 +69,11 @@ const sequence = (
   index ??= 0;
   nodes ??= [];
 
+  if (index >= fns.length) {
+    cb();
+    return nodes;
+  }
+
   nodes.push(
     fns[index](() => {
       index ??= 0;


### PR DESCRIPTION
The `sequence` function (for chaining callbacks), didn't handle the case when there were 0 script tags to evaluate. This is a guaranteed situation to occur when newly creating a page, and was missed during local testing since I was working with an existing page all the time.