### PR TITLE
Fix create_page_for_categories migration having 0 content delta

### DIFF
--- a/backend/pages/migrations/0003_create_page_for_categories.py
+++ b/backend/pages/migrations/0003_create_page_for_categories.py
@@ -80,12 +80,12 @@ def create_pages_for_categories(apps, schema_editor):
         if category.more_markdown_link:
             r = requests.get(category.more_markdown_link)
             new_content = r.text if r.status_code == 200 else ""
+            content_patch = calculate_patch(page.content, new_content)
             page.content = new_content
             page.edited_at = datetime.datetime.now(datetime.UTC)
             page.save()
 
             # Create new revision
-            content_patch = calculate_patch(page.content, new_content)
             PageRevision.objects.create(
                 page=page,
                 author=temp_author,


### PR DESCRIPTION
The import migration from `more_markdown_link` to `Page` created revisions with zero delta because of a misplaced line. This PR fixes it for any new deployments, although it won't fix our prod :( 