### PR TITLE
Add a placeholder text when category has no testimonials

### DIFF
--- a/frontend/src/components/category-testimonials.tsx
+++ b/frontend/src/components/category-testimonials.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@mantine/core";
+import { Stack, Text } from "@mantine/core";
 import { Testimonial } from "../interfaces";
 import { TestimonialCard } from "./testimonial-card";
 
@@ -18,6 +18,11 @@ export const CategoryTestimonials: React.FC<{
           approval_status={testimonial.approval_status}
         />
       ))}
+      {testimonials.length === 0 && (
+        <Text c="dimmed" size="sm">
+          Come back in a few weeks - we're cooking something up here...
+        </Text>
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
#115 enabled the testimonials tab in category pages, but they contain no items since we don't have a way to post a testimonial yet. Despite that, we don't have a placeholder for empty content, and it just looks like something is broken.