### PR TITLE
Implement API endpoints for adding/updating/removing grade stats

### DIFF
--- a/backend/categories/migrations/0021_add_percentile_stats_and_fk.py
+++ b/backend/categories/migrations/0021_add_percentile_stats_and_fk.py
@@ -1,0 +1,144 @@
+# Written manually on 2026.08.20. *Should* be revertible...
+
+# Changes the course_code field in CourseStats to an FK
+# Adds a JSONB field for percentile course stats
+# Some cleanup like adding uniqueness constraints and making field declarations
+#   consistent
+
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+def convert_to_link(apps, schema_editor):
+    CourseStats = apps.get_model("categories", "CourseStats")
+    EuclidCode = apps.get_model("categories", "EuclidCode")
+
+    for stats in CourseStats.objects.all():
+        code = stats.course_code
+        euclid_code = EuclidCode.objects.filter(code=code).first()
+        if euclid_code is None:
+            euclid_code = EuclidCode.objects.create(code=code, category=None)
+        stats.course_code_link = euclid_code
+        stats.save()
+
+def unconvert_from_link(apps, schema_editor):
+    CourseStats = apps.get_model("categories", "CourseStats")
+
+    for stats in CourseStats.objects.all():
+        stats.course_code = stats.course_code_link.code
+        stats.save()
+
+
+def delete_categoryless_codes(apps, schema_editor):
+    EuclidCode = apps.get_model("categories", "EuclidCode")
+    EuclidCode.objects.filter(category=None).delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('categories', '0020_examcounts_add_bitmask'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='coursestats',
+            name='percentiles',
+            field=models.JSONField(default={}),
+            preserve_default=False,
+        ),
+        # Enforce uniqueness
+        migrations.AlterField(
+            model_name='euclidcode',
+            name='code',
+            field=models.CharField(max_length=12, unique=True),
+        ),
+        # Add None to allow euclid code without a category
+        # (Needed since some course stats are not categories, like minf thesis)
+        migrations.AlterField(
+            model_name='euclidcode',
+            name='category',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='euclid_codes', to='categories.category'),
+        ),
+
+        # Reverse constraint flush in case we need to roll back the migration
+        migrations.RunSQL(
+            sql=migrations.RunSQL.noop,
+            reverse_sql="SET CONSTRAINTS ALL IMMEDIATE",
+        ),
+
+        # On the reverse path, delete any EuclidCodes without a category
+        migrations.RunPython(code=migrations.RunPython.noop, reverse_code=delete_categoryless_codes),
+
+        # Change course_code to foreignkey
+        # steps as described in https://stackoverflow.com/a/36000084
+        migrations.AddField(
+            model_name='coursestats',
+            name='course_code_link',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='stats',
+                to='categories.euclidcode',
+                # Temporarily allow null during this migration
+                null=True,
+            ),
+        ),
+        # Reverse constraint flush in case we need to roll back the migration
+        migrations.RunSQL(
+            sql=migrations.RunSQL.noop,
+            reverse_sql="SET CONSTRAINTS ALL IMMEDIATE",
+        ),
+        migrations.RunPython(code=convert_to_link, reverse_code=unconvert_from_link),
+        # Need to flush the constraints before we can fiddle around with the
+        # FK fields, otherwise Django complains about not wanting to alter table
+        # with pending trigger events.
+        migrations.RunSQL(
+            sql="SET CONSTRAINTS ALL IMMEDIATE",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        # Set a default value for the course_code field, which doesn't do much
+        # in forward (since the field is removed in the next line) but is crucial
+        # for backwards migration, otherwise un-RemoveField will try to create
+        # a non-nullable field with no default value and fail
+        migrations.AlterField(
+            model_name='coursestats',
+            name='course_code',
+            field=models.CharField(max_length=12, db_index=True, default=''),
+        ),
+        migrations.RemoveField(
+            model_name='coursestats',
+            name='course_code',
+        ),
+        migrations.RenameField(
+            model_name='coursestats',
+            old_name='course_code_link',
+            new_name='course_code',
+        ),
+        migrations.AlterField(
+            model_name='coursestats',
+            name='course_code',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='stats',
+                to='categories.euclidcode',
+                # Disallow nulls
+                null=False,
+            ),
+        ),
+
+        # Remove blank=True (which only affects Django's admin interface)
+        migrations.AlterField(
+            model_name='coursestats',
+            name='course_organiser',
+            field=models.CharField(max_length=256, null=True),
+        ),
+        migrations.AlterField(
+            model_name='coursestats',
+            name='mean_mark',
+            field=models.FloatField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='coursestats',
+            name='std_deviation',
+            field=models.FloatField(null=True),
+        ),
+    ]

--- a/backend/categories/models.py
+++ b/backend/categories/models.py
@@ -90,7 +90,7 @@ class EuclidCode(models.Model):
     # show to users which courses on DRPS the category corresponds to, and
     # for admins, automatically analyse which courses are missing as categories.
     code = models.CharField(max_length=12, unique=True)
-    category = models.ForeignKey(
+    category: models.ForeignKey[Category | None] = models.ForeignKey(
         "Category", related_name="euclid_codes", on_delete=models.CASCADE, null=True
     )
 

--- a/backend/categories/models.py
+++ b/backend/categories/models.py
@@ -89,26 +89,28 @@ class EuclidCode(models.Model):
     # shadow courses (same course offered to UG/PG etc). This is used to both
     # show to users which courses on DRPS the category corresponds to, and
     # for admins, automatically analyse which courses are missing as categories.
-    code = models.CharField(max_length=12)
+    code = models.CharField(max_length=12, unique=True)
     category = models.ForeignKey(
-        "Category", related_name="euclid_codes", on_delete=models.CASCADE
+        "Category", related_name="euclid_codes", on_delete=models.CASCADE, null=True
     )
+
+    # Reverse type hints
+    stats: models.QuerySet["CourseStats"]  # disambiguate by academic_year
 
 
 class CourseStats(models.Model):
+    course_code: models.ForeignKey[EuclidCode] = models.ForeignKey(
+        "EuclidCode", related_name="stats", on_delete=models.CASCADE
+    )
     course_name = models.CharField(max_length=256)
-    course_code = models.CharField(max_length=12, db_index=True)
-    mean_mark = models.FloatField(null=True, blank=True)  # Can be null for N/A values
-    std_deviation = models.FloatField(
-        null=True, blank=True
-    )  # Can be null for N/A values
+    mean_mark = models.FloatField(null=True)
+    std_deviation = models.FloatField(null=True)
     academic_year = models.CharField(max_length=10)  # e.g. "2023-24"
-    course_organiser = models.CharField(
-        max_length=256, null=True, blank=True
-    )  # Course Organiser name
+    course_organiser = models.CharField(max_length=256, null=True)
+    percentiles = models.JSONField()
 
     class Meta:
         ordering = ["course_code", "academic_year"]
 
     def __str__(self):
-        return f"{self.course_code} ({self.academic_year}): {self.mean_mark}"
+        return f"{self.course_code.code} ({self.academic_year}): {self.mean_mark}"

--- a/backend/categories/tests.py
+++ b/backend/categories/tests.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 
-from categories.models import Category, MetaCategory
+from categories.models import Category, EuclidCode, MetaCategory
 from testing.tests import ComsolTest, ComsolTestExamsData
 
 
@@ -250,6 +250,82 @@ class TestMetaCategories(ComsolTest):
                 "order": 9,
             },
         )
+
+
+class TestCourseStats(ComsolTest):
+    def mySetUp(self):
+        self.cat1 = Category(displayname="Test 1", slug="test1")
+        self.cat1.save()
+
+        self.euclid_code = EuclidCode(code="INFR10000", category=self.cat1)
+        self.euclid_code.save()
+
+    def test_add_course_stats(self):
+        self.post(
+            "/api/category/addstats/INFR10000/2023-24/",
+            {
+                "course_name": "Test Course",
+                "mean_mark": 75.0,
+                "std_deviation": 10.0,
+                "percentiles": '{"50": 60, "75": 80, "90": 95}',
+                "course_organiser": "Dr. Test",
+            },
+        )
+        res = self.get("/api/category/stats/test1/")["value"]
+        res_course = next((c for c in res if c["course_code"] == "INFR10000"), None)
+        self.assertEqual(res_course["academic_year"], "2023-24")
+        self.assertEqual(res_course["course_name"], "Test Course")
+        self.assertEqual(res_course["mean_mark"], 75.0)
+        self.assertEqual(res_course["std_deviation"], 10.0)
+        self.assertEqual(res_course["percentiles"], {"50": 60, "75": 80, "90": 95})
+        self.assertEqual(res_course["course_organiser"], "Dr. Test")
+
+    def test_update_course_stats(self):
+        self.post(
+            "/api/category/addstats/INFR10000/2023-24/",
+            {
+                "course_name": "Test Course",
+                "mean_mark": 75.0,
+                "std_deviation": 10.0,
+                "percentiles": '{"50": 60, "75": 80, "90": 95}',
+                "course_organiser": "Dr. Test",
+            },
+        )
+        self.patch(
+            "/api/category/updatestats/INFR10000/2023-24/",
+            {
+                "mean_mark": 80.0,
+                "std_deviation": 8.0,
+                "percentiles": '{"25": 20, "50": 60, "75": 40, "90": 95}',
+            },
+        )
+        res = self.get("/api/category/stats/test1/")["value"]
+        res_course = next((c for c in res if c["course_code"] == "INFR10000"), None)
+        self.assertEqual(res_course["academic_year"], "2023-24")
+        self.assertEqual(res_course["course_name"], "Test Course")
+        self.assertEqual(res_course["mean_mark"], 80.0)
+        self.assertEqual(res_course["std_deviation"], 8.0)
+        self.assertEqual(
+            res_course["percentiles"], {"25": 20, "50": 60, "75": 40, "90": 95}
+        )
+        self.assertEqual(res_course["course_organiser"], "Dr. Test")
+
+    def test_delete_course_stats(self):
+        self.post(
+            "/api/category/addstats/INFR10000/2023-24/",
+            {
+                "course_name": "Test Course",
+                "mean_mark": 75.0,
+                "std_deviation": 10.0,
+                "percentiles": '{"50": 60, "75": 80, "90": 95}',
+                "course_organiser": "Dr. Test",
+            },
+        )
+        self.delete(
+            "/api/category/deletestats/INFR10000/2023-24/",
+        )
+        res = self.get("/api/category/stats/test1/")["value"]
+        self.assertEqual(len(res), 0)
 
 
 # TODO: test whether the counts returned in list_exams and withmeta are correct

--- a/backend/categories/urls.py
+++ b/backend/categories/urls.py
@@ -42,4 +42,19 @@ urlpatterns = [
     ),
     path("listeuclidcodes/", views.list_euclid_codes, name="listeuclidcodes"),
     path("stats/<slug:slug>/", views.get_course_stats, name="course_stats"),
+    path(
+        "addstats/<str:code>/<str:academic_year>/",
+        views.add_course_stats,
+        name="add_course_stats",
+    ),
+    path(
+        "updatestats/<str:code>/<str:academic_year>/",
+        views.update_course_stats,
+        name="update_course_stats",
+    ),
+    path(
+        "deletestats/<str:code>/<str:academic_year>/",
+        views.delete_course_stats,
+        name="delete_course_stats",
+    ),
 ]

--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -474,11 +474,20 @@ def add_euclid_code(request, slug):
         return response.not_possible("Code too long")
 
     # Check if code is already assigned to another category, if so return the name of it
-    if cat.euclid_codes.filter(code=code).exists():
+    euclid_code = EuclidCode.objects.filter(code=code).first()
+    if euclid_code and euclid_code.category and euclid_code.category != cat:
         return response.not_possible(
-            f"Code already assigned to category {cat.euclid_codes.get(code=code).category.displayname}"
+            f"Code already assigned to category {euclid_code.category.displayname}"
         )
-    cat.euclid_codes.create(code=code)
+
+    if euclid_code and not euclid_code.category:
+        # Still not taken
+        euclid_code.category = cat
+        euclid_code.save()
+
+    if not euclid_code:
+        cat.euclid_codes.create(code=code, category=cat)
+
     return response.success()
 
 
@@ -487,7 +496,7 @@ def add_euclid_code(request, slug):
 def remove_euclid_code(request, slug):
     cat = get_object_or_404(Category, slug=slug)
     code = request.POST["code"].upper()
-    cat.euclid_codes.filter(code=code).delete()
+    cat.euclid_codes.filter(code=code).update(category=None)
     return response.success()
 
 
@@ -500,7 +509,11 @@ def get_category_from_euclid_code(request):
 
 @response.request_get()
 def list_euclid_codes(request):
-    codes = EuclidCode.objects.all()
+    codes = (
+        EuclidCode.objects.all()
+        .filter(category__isnull=False)
+        .select_related("category")
+    )
     res = [
         {
             "code": code.code,

--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -520,14 +520,14 @@ def get_course_stats(request, slug):
         return response.success(value=[])
 
     # Get course stats for all Euclid codes associated with this category
-    stats = CourseStats.objects.filter(course_code__in=euclid_codes).order_by(
-        "course_code", "academic_year"
+    stats = CourseStats.objects.filter(course_code__code__in=euclid_codes).order_by(
+        "course_code__code", "academic_year"
     )
 
     res = [
         {
             "course_name": stat.course_name,
-            "course_code": stat.course_code,
+            "course_code": stat.course_code.code,
             "mean_mark": stat.mean_mark,
             "std_deviation": stat.std_deviation,
             "academic_year": stat.academic_year,

--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -1,3 +1,6 @@
+import json
+import re
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import Exists, OuterRef
@@ -532,8 +535,114 @@ def get_course_stats(request, slug):
             "std_deviation": stat.std_deviation,
             "academic_year": stat.academic_year,
             "course_organiser": stat.course_organiser,
+            "percentiles": stat.percentiles,
         }
         for stat in stats
     ]
 
     return response.success(value=res)
+
+
+@response.request_post()
+@auth_check.require_admin
+def add_course_stats(request, code, academic_year):
+    euclid_code = get_object_or_404(EuclidCode, code=code)
+
+    # Extract data from request
+    course_name = request.POST.get("course_name")
+    mean_mark = request.POST.get("mean_mark")
+    std_deviation = request.POST.get("std_deviation")
+    course_organiser = request.POST.get("course_organiser")
+    percentiles = request.POST.get("percentiles")
+
+    # Course name must be specified
+    if not course_name:
+        return response.not_possible("Course name must be specified")
+
+    # Any of mean, std, and percentiles must be specified
+    if not any([mean_mark, std_deviation, percentiles]):
+        return response.not_possible(
+            "At least one of mean_mark, std_deviation, or percentiles must be specified"
+        )
+
+    if not percentiles:
+        percentiles = {}
+    else:
+        try:
+            percentiles = json.loads(percentiles)
+        except json.JSONDecodeError:
+            return response.not_possible("Percentiles must be a valid JSON object")
+
+    if CourseStats.objects.filter(
+        course_code=euclid_code, academic_year=academic_year
+    ).exists():
+        return response.not_possible(
+            f"Course stats for {code} in {academic_year} exists - use update"
+        )
+
+    # Check academic year format
+    regex = re.compile(r"^\d{4}-\d{2}$")
+    if not regex.match(academic_year):
+        return response.not_possible("Academic year must be in the format YYYY-YY")
+
+    # Create new CourseStats entry
+    stats = CourseStats(
+        course_code=euclid_code,
+        course_name=course_name,
+        mean_mark=mean_mark,
+        std_deviation=std_deviation,
+        academic_year=academic_year,
+        course_organiser=course_organiser,
+        percentiles=percentiles,
+    )
+    stats.save()
+
+    return response.success()
+
+
+@response.request_patch()
+@auth_check.require_admin
+def update_course_stats(request, code, academic_year):
+    euclid_code = get_object_or_404(EuclidCode, code=code)
+
+    # Extract data from request
+    course_name = request.POST.get("course_name")
+    mean_mark = request.POST.get("mean_mark")
+    std_deviation = request.POST.get("std_deviation")
+    course_organiser = request.POST.get("course_organiser")
+    percentiles = request.POST.get("percentiles")
+
+    stats = get_object_or_404(
+        CourseStats, course_code=euclid_code, academic_year=academic_year
+    )
+
+    if course_name is not None:
+        stats.course_name = course_name
+    if mean_mark is not None:
+        stats.mean_mark = mean_mark
+    if std_deviation is not None:
+        stats.std_deviation = std_deviation
+    if course_organiser is not None:
+        stats.course_organiser = course_organiser
+    if percentiles is not None:
+        try:
+            stats.percentiles = json.loads(percentiles)
+        except json.JSONDecodeError:
+            return response.not_possible("Percentiles must be a valid JSON object")
+
+    stats.save()
+
+    return response.success()
+
+
+@response.request_delete()
+@auth_check.require_admin
+def delete_course_stats(request, code, academic_year):
+    euclid_code = get_object_or_404(EuclidCode, code=code)
+
+    stats = get_object_or_404(
+        CourseStats, course_code=euclid_code, academic_year=academic_year
+    )
+    stats.delete()
+
+    return response.success()


### PR DESCRIPTION
Initial rounds of grade statistics were populated last year by manually running a Python script on the production host and inserting rows into the database directly. This is not a sustainable method to maintain grade statistics.

This pull request implements POST/PATCH/DELETE endpoints for grade stats. Additionally, we clean up the model by changing `CourseStats.course_code` from a text field to a proper foreign key, and adding optional percentile information for more granular stats in the future. It's all a reversible migration too! (it was pain)

Tests included.

Honestly I want to move the Categories API over to Django Ninja ASAP, since coming back to write plain endpoints for this PR was pretty painful without the automated typechecks...