### PR TITLE
Add nonce-based CSP exception to trusted guide pages

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 import yaml
+from csp.constants import NONCE
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -213,6 +214,8 @@ CONTENT_SECURITY_POLICY = {
             "'self'",
             "'unsafe-eval'",
             "https://analytics.betterinformatics.com/api/",
+            # Allow nonce-based inline scripts for guide pages
+            NONCE,
             # Captchas
             "https://challenges.cloudflare.com",
             *allowed_script_sources,

--- a/backend/pages/api.py
+++ b/backend/pages/api.py
@@ -188,6 +188,13 @@ def list_pages(
 def get_page(request, slug: str):
     page = get_object_or_404(Page, slug=slug)
 
+    # If static_html, add the CSP nonce to any inline scripts in the content
+    if page.kind == Page.Kind.STATIC_HTML:
+        nonce = request.csp_nonce
+        page.content = page.content.replace(
+            "<script>", f'<script nonce="{nonce}">'
+        ).replace("<script ", f'<script nonce="{nonce}" ')
+
     return PageResponse(
         title=page.title,
         slug=page.slug,


### PR DESCRIPTION
For `static_html` based guide pages, this PR implements a CSP exception through nonces. This assumes trust in the BI admins who have the permissions to create/update such pages. I deem this to be fine, since a compromised admin (or browser/extension that an admin has installed) can perform requests to all API endpoints anyway, which can be used to perform the same or worse kinds of attacks that a CSP bypass would.