### PR TITLE
Allow duplicate course stats differentiated by source name/date

### DIFF
--- a/backend/categories/migrations/0023_alter_coursestats_options_coursestats_source_date_and_more.py
+++ b/backend/categories/migrations/0023_alter_coursestats_options_coursestats_source_date_and_more.py
@@ -1,0 +1,83 @@
+# Written manually on 2020.08.21
+
+from django.db import migrations, models
+import datetime
+
+def populate_sources(apps, schema_editor):
+    CourseStats = apps.get_model("categories", "CourseStats")
+    for stat in CourseStats.objects.all():
+
+        if stat.academic_year == "2017-18":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2018, 10, 18)
+
+        elif stat.academic_year == "2018-19":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2019, 7, 10)
+
+        elif stat.academic_year == "2019-20":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2020, 8, 5)
+
+        elif stat.academic_year == "2020-21":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2021, 7, 8)
+
+        elif stat.academic_year == "2021-22":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2022, 7, 4)
+
+        elif stat.academic_year == "2022-23":
+            stat.source_name = "web.inf.ed.ac.uk"
+            stat.source_date = datetime.date(2023, 7, 11)
+
+        elif stat.academic_year == "2023-24":
+            stat.source_name = "sharepoint"
+            stat.source_date = datetime.date(2025, 9, 14)
+
+        elif stat.academic_year == "2024-25":
+            stat.source_name = "sharepoint"
+            stat.source_date = datetime.date(2025, 9, 14)
+
+        stat.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('categories', '0022_coursestats_add_student_count'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='coursestats',
+            options={'ordering': ['course_code__code', 'academic_year', 'source_date']},
+        ),
+        migrations.AddField(
+            model_name='coursestats',
+            name='source_date',
+            field=models.DateField(null=True),
+        ),
+        migrations.AddField(
+            model_name='coursestats',
+            name='source_name',
+            field=models.CharField(null=True, max_length=256),
+        ),
+        migrations.RunPython(
+            code=populate_sources,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name='coursestats',
+            name='source_date',
+            field=models.DateField(),
+        ),
+        migrations.AlterField(
+            model_name='coursestats',
+            name='source_name',
+            field=models.CharField(max_length=256),
+        ),
+        migrations.AddConstraint(
+            model_name='coursestats',
+            constraint=models.UniqueConstraint(fields=('course_code', 'academic_year', 'source_name', 'source_date'), name='unique_course_stats'),
+        ),
+    ]

--- a/backend/categories/models.py
+++ b/backend/categories/models.py
@@ -109,9 +109,19 @@ class CourseStats(models.Model):
     academic_year = models.CharField(max_length=10)  # e.g. "2023-24"
     course_organiser = models.CharField(max_length=256, null=True)
     percentiles = models.JSONField()
+    source_name = models.CharField(max_length=256)
+    source_date = models.DateField()
 
     class Meta:
-        ordering = ["course_code", "academic_year"]
+        ordering = ["course_code__code", "academic_year", "source_date"]
+
+        constraints = [
+            # 4-tuple of (course_code, academic_year, source_name, source_date) must be unique
+            models.UniqueConstraint(
+                fields=["course_code", "academic_year", "source_name", "source_date"],
+                name="unique_course_stats",
+            )
+        ]
 
     def __str__(self):
         return f"{self.course_code.code} ({self.academic_year}): {self.mean_mark}"

--- a/backend/categories/tests.py
+++ b/backend/categories/tests.py
@@ -269,6 +269,8 @@ class TestCourseStats(ComsolTest):
                 "std_deviation": 10.0,
                 "percentiles": '{"50": 60, "75": 80, "90": 95}',
                 "course_organiser": "Dr. Test",
+                "source_name": "ABC/test",
+                "source_date": "2023-06-01",
             },
         )
         res = self.get("/api/category/stats/test1/")["value"]
@@ -279,6 +281,8 @@ class TestCourseStats(ComsolTest):
         self.assertEqual(res_course["std_deviation"], 10.0)
         self.assertEqual(res_course["percentiles"], {"50": 60, "75": 80, "90": 95})
         self.assertEqual(res_course["course_organiser"], "Dr. Test")
+        self.assertEqual(res_course["source_name"], "ABC/test")
+        self.assertEqual(res_course["source_date"], "2023-06-01")
 
     def test_update_course_stats(self):
         self.post(
@@ -289,6 +293,8 @@ class TestCourseStats(ComsolTest):
                 "std_deviation": 10.0,
                 "percentiles": '{"50": 60, "75": 80, "90": 95}',
                 "course_organiser": "Dr. Test",
+                "source_name": "ABC/test",
+                "source_date": "2023-06-01",
             },
         )
         self.patch(
@@ -298,6 +304,8 @@ class TestCourseStats(ComsolTest):
                 "std_deviation": 8.0,
                 "student_count": 100,
                 "percentiles": '{"25": 20, "50": 60, "75": 40, "90": 95}',
+                "source_name": "ABC/test",
+                "source_date": "2023-06-01",
             },
         )
         res = self.get("/api/category/stats/test1/")["value"]
@@ -311,6 +319,8 @@ class TestCourseStats(ComsolTest):
             res_course["percentiles"], {"25": 20, "50": 60, "75": 40, "90": 95}
         )
         self.assertEqual(res_course["course_organiser"], "Dr. Test")
+        self.assertEqual(res_course["source_name"], "ABC/test")
+        self.assertEqual(res_course["source_date"], "2023-06-01")
 
     def test_delete_course_stats(self):
         self.post(
@@ -321,10 +331,13 @@ class TestCourseStats(ComsolTest):
                 "std_deviation": 10.0,
                 "percentiles": '{"50": 60, "75": 80, "90": 95}',
                 "course_organiser": "Dr. Test",
+                "source_name": "ABC/test",
+                "source_date": "2023-06-01",
             },
         )
+
         self.delete(
-            "/api/category/deletestats/INFR10000/2023-24/",
+            "/api/category/deletestats/INFR10000/2023-24/?source_name=ABC/test&source_date=2023-06-01",
         )
         res = self.get("/api/category/stats/test1/")["value"]
         self.assertEqual(len(res), 0)

--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -537,7 +537,7 @@ def get_course_stats(request, slug):
 
     # Get course stats for all Euclid codes associated with this category
     stats = CourseStats.objects.filter(course_code__code__in=euclid_codes).order_by(
-        "course_code__code", "academic_year"
+        "course_code__code", "academic_year", "source_date"
     )
 
     res = [
@@ -548,6 +548,8 @@ def get_course_stats(request, slug):
             "std_deviation": stat.std_deviation,
             "student_count": stat.student_count,
             "academic_year": stat.academic_year,
+            "source_name": stat.source_name,
+            "source_date": stat.source_date.isoformat() if stat.source_date else None,
             "course_organiser": stat.course_organiser,
             "percentiles": stat.percentiles,
         }
@@ -569,10 +571,15 @@ def add_course_stats(request, code, academic_year):
     student_count = request.POST.get("student_count")
     course_organiser = request.POST.get("course_organiser")
     percentiles = request.POST.get("percentiles")
+    source_name = request.POST.get("source_name")
+    source_date = request.POST.get("source_date")
 
     # Course name must be specified
     if not course_name:
         return response.not_possible("Course name must be specified")
+
+    if not source_name or not source_date:
+        return response.not_possible("Source name and date must be specified")
 
     # Any of mean, std, and percentiles must be specified
     if not any([mean_mark, std_deviation, percentiles]):
@@ -589,10 +596,13 @@ def add_course_stats(request, code, academic_year):
             return response.not_possible("Percentiles must be a valid JSON object")
 
     if CourseStats.objects.filter(
-        course_code=euclid_code, academic_year=academic_year
+        course_code=euclid_code,
+        academic_year=academic_year,
+        source_name=source_name,
+        source_date=source_date,
     ).exists():
         return response.not_possible(
-            f"Course stats for {code} in {academic_year} exists - use update"
+            f"Course stats for {code} in {academic_year} exists from this source - use update or change source name/date"
         )
 
     # Check academic year format
@@ -610,6 +620,8 @@ def add_course_stats(request, code, academic_year):
         academic_year=academic_year,
         course_organiser=course_organiser,
         percentiles=percentiles,
+        source_name=source_name,
+        source_date=source_date,
     )
     stats.save()
 
@@ -628,9 +640,15 @@ def update_course_stats(request, code, academic_year):
     student_count = request.POST.get("student_count")
     course_organiser = request.POST.get("course_organiser")
     percentiles = request.POST.get("percentiles")
+    source_name = request.POST.get("source_name")
+    source_date = request.POST.get("source_date")
 
     stats = get_object_or_404(
-        CourseStats, course_code=euclid_code, academic_year=academic_year
+        CourseStats,
+        course_code=euclid_code,
+        academic_year=academic_year,
+        source_name=source_name,
+        source_date=source_date,
     )
 
     if course_name is not None:
@@ -659,8 +677,15 @@ def update_course_stats(request, code, academic_year):
 def delete_course_stats(request, code, academic_year):
     euclid_code = get_object_or_404(EuclidCode, code=code)
 
+    source_name = request.GET.get("source_name")
+    source_date = request.GET.get("source_date")
+
     stats = get_object_or_404(
-        CourseStats, course_code=euclid_code, academic_year=academic_year
+        CourseStats,
+        course_code=euclid_code,
+        academic_year=academic_year,
+        source_name=source_name,
+        source_date=source_date,
     )
     stats.delete()
 


### PR DESCRIPTION
Some (actually, many) courses have multiple grade statistics published, likely due to the timing of the publication and whether or not they count resit exams and/or failed students. This means we should change our code to allow distinguishing stats by not only course code and year, but also by the source of the data.

For that reason, I added `source_date` and `source_name` to the CourseStats model. Source Name is rather arbitrary, but is used for de-duplicating, while source_date is used for both de-duplicating and ordering multiple stats.