### PR TITLE
Allow guest users to browse course guides from parent guides

### DIFF
--- a/frontend/src/components/page-article.module.css
+++ b/frontend/src/components/page-article.module.css
@@ -65,3 +65,7 @@
     var(--mantine-h1-line-height) * var(--mantine-h1-font-size)
   );
 }
+
+.categories-list {
+  animation: fadeInUp 0.2s ease-in-out;
+}

--- a/frontend/src/components/page-article.tsx
+++ b/frontend/src/components/page-article.tsx
@@ -284,7 +284,7 @@ export const PageArticle: React.FC<{
                 Relevant Categories
               </Title>
             </Group>
-            <List>
+            <List className={style.categoriesList}>
               {childPagesWithCat.map(page => (
                 <List.Item key={page.slug}>
                   <Anchor

--- a/frontend/src/components/page-article.tsx
+++ b/frontend/src/components/page-article.tsx
@@ -289,7 +289,11 @@ export const PageArticle: React.FC<{
                 <List.Item key={page.slug}>
                   <Anchor
                     component={Link}
-                    to={`/category/${page.category?.slug}/guide`}
+                    to={
+                      user?.loggedin
+                        ? `/category/${page.category?.slug}/guide`
+                        : `/guide/${page.slug}`
+                    }
                   >
                     {page.category?.displayname}
                   </Anchor>


### PR DESCRIPTION
The "relevant categories" links in guide pages was gated for auth despite not needing it, this PR fixes it so guide pages are directly browsable too.