### PR TITLE
Use GitHub App to work around workflow approval requirement

### DIFF
--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -45,9 +45,16 @@ jobs:
           fi
           echo "base_branch=$base_branch" >> "$GITHUB_OUTPUT"
 
+      - name: Generate a token for BI app
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.BI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BI_APP_PRIVATE_KEY }}
+
       - name: Mark PR as ready and set title
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh pr ready ${{ github.event.issue.number }} \
             --repo ${{ github.repository }}
@@ -59,13 +66,12 @@ jobs:
       - name: Checkout next-release branch
         uses: actions/checkout@v6
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
           ref: next-release
 
       - name: Generate changelog for explicit version
         id: changelog
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           release_name="${{ steps.parse.outputs.release_name }}"
           base_branch="${{ steps.verify.outputs.base_branch }}"
@@ -128,10 +134,13 @@ jobs:
           cat ONLY_NEW.md >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
+      # We specifically use a GitHub App here, because in mid-2026 GitHub
+      # started requiring approvals for workflows on PRs updated by the default
+      # GITHUB_TOKEN. see: https://github.com/orgs/community/discussions/199292
       - name: Commit changelog update
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Better Informatics"
+          git config user.email "42103905+better-informatics[bot]@users.noreply.github.com"
 
           git add CHANGELOG.md
           if git diff --cached --quiet; then
@@ -143,7 +152,7 @@ jobs:
 
       - name: Update PR body with changelog
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           raw_body="${{ steps.changelog.outputs.raw_new }}"
           printf '%s\n' '<table><tbody><tr><td>' '' "$raw_body" '' '</td></tr></tbody></table>' '' 'This PR tracks the upcoming release and keeps an automatically generated changelog for it. It auto-rebases when the master branch ref is updated.' '' 'Comment "/release v<version number>" when it is time to release the next version.' 'This will mark the PR as Ready and regenerate the changelog with the specified version. (Note that this will overwrite any manual commits.)' 'After "/release", you can manually edit the changelog if necessary.' 'Finally, squash-merge this PR to create the release.' > pr-body.txt
@@ -154,7 +163,7 @@ jobs:
 
       - name: Post instructions comment
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           release_name="${{ steps.parse.outputs.release_name }}"
           gh pr comment ${{ github.event.issue.number }} \

--- a/.github/workflows/release_pr_creator.yaml
+++ b/.github/workflows/release_pr_creator.yaml
@@ -73,10 +73,18 @@ jobs:
         (startsWith(github.ref, 'refs/tags/') && needs.determine_base_branch.outputs.base_branch == 'master')
       )
     steps:
+      - name: Generate a token for BI app
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.BI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BI_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Resolve since-tag and base branch
         id: context
@@ -93,7 +101,7 @@ jobs:
       - name: Check for existing PR title
         id: existing_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           existing_title=$(gh pr list \
             --head next-release \
@@ -170,13 +178,16 @@ jobs:
             echo CI_RAW_CHANGELOG_NEW
           } >> "$GITHUB_OUTPUT"
 
+      # We specifically use a GitHub App here, because in mid-2026 GitHub
+      # started requiring approvals for workflows on PRs created by the default
+      # GITHUB_TOKEN. see: https://github.com/orgs/community/discussions/199292
       - name: Create or update pull request
         id: create_update_pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "Better Informatics"
+          git config user.email "42103905+better-informatics[bot]@users.noreply.github.com"
 
           git checkout -B next-release
           git add CHANGELOG.md
@@ -235,18 +246,20 @@ jobs:
         needs.check_changelog_pr.outputs.version != ''
       )
     steps:
-      - name: Checkout repository with SSH
+      - name: Generate a token for BI app
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.BI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BI_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # We need to use a custom deploy key, since GITHUB_TOKEN pushing tags
-          # will not re-trigger the tag push workflow (some default recursion
-          # prevention thing). We need to trigger it to create the new changelog
-          # PR and cause a deployment rollout.
-          ssh-key: ${{ secrets.CI_COMMIT_KEY }}
+          token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Push tag over SSH
+      - name: Push tag
         run: |
           git tag "${{ needs.check_changelog_pr.outputs.version }}" "${{ github.sha }}"
-          git remote set-url origin "git@github.com:${{ github.repository }}.git"
           git push origin "refs/tags/${{ needs.check_changelog_pr.outputs.version }}"


### PR DESCRIPTION
Per https://github.com/orgs/community/discussions/199292, PRs created/updated by the default GITHUB_TOKEN (and thus the github-actions[bot] user) require manual approval to run workflows. This gets really annoying for our "Next Release" PRs, since CIs for every force push made there requires clicking on a button manually.

This PR attempts to move to a GitHub App, which *shouldn't* be affected by this change (says other people online). Repository secrets and variables have been created already.