### PR TITLE
Fix request_get(param) being broken after d284be89

### DIFF
--- a/backend/categories/views.py
+++ b/backend/categories/views.py
@@ -501,8 +501,10 @@ def remove_euclid_code(request, slug):
     return response.success()
 
 
-@response.request_get("code")
+@response.request_get()
 def get_category_from_euclid_code(request):
+    if "code" not in request.GET:
+        return response.not_possible("Missing code parameter")
     code = request.GET["code"].upper()
     cat = get_object_or_404(Category, euclid_codes__code=code)
     return response.success(value=cat.slug)


### PR DESCRIPTION
There was faulty logic in `d284be89` that assumed required arguments for a GET request would also have be in request.POST body. This is breaking exam_shtocker.

We patch it for now by not using `request_get()` with a parameter.