### PR TITLE
Make Editor and HtmlEditor lazy in guide pages

### DIFF
--- a/frontend/src/components/html-editor.tsx
+++ b/frontend/src/components/html-editor.tsx
@@ -191,3 +191,5 @@ export const HtmlEditor: React.FC<Props> = ({
     </div>
   );
 };
+
+export default HtmlEditor;

--- a/frontend/src/components/markdown-text.tsx
+++ b/frontend/src/components/markdown-text.tsx
@@ -12,11 +12,12 @@ import "katex/dist/katex.min.css";
 import * as React from "react";
 import { useMemo } from "react";
 import { escapeRegExp } from "lodash-es";
-import CodeBlock from "./code-block";
-import { Alert, Table } from "@mantine/core";
+import { Alert, Skeleton, Table } from "@mantine/core";
 import ErrorBoundary from "./error-boundary";
 import { clsx } from "clsx";
 import classes from "./markdown-text.module.css";
+
+const CodeBlock = React.lazy(() => import("./code-block"));
 
 const transformImageUri = (
   uri: string,
@@ -173,10 +174,18 @@ const createComponents = (
       });
     }
     return language ? (
-      <CodeBlock
-        language={language}
-        value={String(children).replace(/\n$/, "")}
-      />
+      <React.Suspense
+        fallback={
+          <Skeleton ff="monospace">
+            {String(children).replace(/\n$/, "")}
+          </Skeleton>
+        }
+      >
+        <CodeBlock
+          language={language}
+          value={String(children).replace(/\n$/, "")}
+        />
+      </React.Suspense>
     ) : (
       <code className={className} {...props}>
         {children}

--- a/frontend/src/components/page-article.tsx
+++ b/frontend/src/components/page-article.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { lazy, Suspense, useState } from "react";
 import {
   PageListResponse,
   PageListResponseItem,
@@ -15,6 +15,7 @@ import {
   MultiSelect,
   Paper,
   Select,
+  Skeleton,
   Text,
   TextInput,
   Title,
@@ -22,7 +23,7 @@ import {
 import MarkdownText, { slugifyHeading } from "./markdown-text";
 import { IconBook, IconHierarchy } from "@tabler/icons-react";
 import style from "./page-article.module.css";
-import Editor from "./Editor";
+const Editor = lazy(() => import("./Editor"));
 import { UndoStack } from "./Editor/utils/undo-stack";
 import { GuideSidebarRight } from "./guide-sidebar-right";
 import { useTableOfContents } from "../hooks/useTableOfContents";
@@ -35,7 +36,7 @@ import { Link, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import { Turnstile } from "@marsidev/react-turnstile";
 import { ExtremelyTrustedHTML } from "./extremely-trusted-html";
 import { usePendingImages } from "./Editor/pending-images";
-import { HtmlEditor } from "./html-editor";
+const HtmlEditor = lazy(() => import("./html-editor"));
 import useTitle from "../hooks/useTitle";
 import { PageArticleContent } from "./page-article-content";
 import serverData from "../utils/server-data";
@@ -201,35 +202,43 @@ export const PageArticle: React.FC<{
         )}
         {editing ? (
           page.kind === "static_html" ? (
-            <HtmlEditor
-              value={formState.content}
-              onChange={value => setFormValue("content", value)}
-              imageHandler={deferredImageHandler}
-              undoStack={undoStack}
-              setUndoStack={setUndoStack}
-              preview={value => <ExtremelyTrustedHTML html={value} />}
-            />
+            <Suspense
+              fallback={<Skeleton ff="monospace">{formState.content}</Skeleton>}
+            >
+              <HtmlEditor
+                value={formState.content}
+                onChange={value => setFormValue("content", value)}
+                imageHandler={deferredImageHandler}
+                undoStack={undoStack}
+                setUndoStack={setUndoStack}
+                preview={value => <ExtremelyTrustedHTML html={value} />}
+              />
+            </Suspense>
           ) : (
-            <Editor
-              allowOfficialAnswer={false}
-              imageHandler={deferredImageHandler}
-              undoStack={undoStack}
-              setUndoStack={setUndoStack}
-              preview={value => (
-                <MarkdownText
-                  value={value}
-                  addAnchors={true}
-                  localLinkBase="https://betterinformatics.com"
-                  ignoreHtml={true}
-                  pendingImages={pendingObjectUrls}
-                />
-              )}
-              /* Manually unpack registerInput since Editor takes a different type for onChange */
-              value={formState.content}
-              onChange={value => {
-                setFormValue("content", value);
-              }}
-            />
+            <Suspense
+              fallback={<Skeleton ff="monospace">{formState.content}</Skeleton>}
+            >
+              <Editor
+                allowOfficialAnswer={false}
+                imageHandler={deferredImageHandler}
+                undoStack={undoStack}
+                setUndoStack={setUndoStack}
+                preview={value => (
+                  <MarkdownText
+                    value={value}
+                    addAnchors={true}
+                    localLinkBase="https://betterinformatics.com"
+                    ignoreHtml={true}
+                    pendingImages={pendingObjectUrls}
+                  />
+                )}
+                /* Manually unpack registerInput since Editor takes a different type for onChange */
+                value={formState.content}
+                onChange={value => {
+                  setFormValue("content", value);
+                }}
+              />
+            </Suspense>
           )
         ) : (
           <PageArticleContent page={page} />

--- a/frontend/src/pages/guide-page.tsx
+++ b/frontend/src/pages/guide-page.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { Suspense } from "react";
 import {
   Anchor,
   Container,
   Drawer,
   Flex,
   Group,
+  Loader,
   Paper,
   Portal,
 } from "@mantine/core";
@@ -61,7 +62,9 @@ const GuideArticlePage: React.FC = () => {
             </Anchor>
           </Portal>
         )}
-        <Outlet />
+        <Suspense fallback={<Loader />}>
+          <Outlet />
+        </Suspense>
       </Flex>
     </Container>
   );


### PR DESCRIPTION
Loading Editor lazily (like all other pages do) reduces page bundle size for guide pages. Additionally, HtmlEditor also now supports lazy loading.