### PR TITLE
Add courses.json endpoint for serving S3 content if it exists

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -72,6 +72,7 @@ urlpatterns = [
         },
     ),
     path("metrics/", restrict_proxied(exports.ExportToDjangoView)),
+    path("courses.json", views.courses_json),
 ]
 
 if DEBUG:

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,10 +1,13 @@
 import logging
 import sys
 
+import yaml
+from botocore.exceptions import ClientError
+from django.http import JsonResponse
 from django.utils.cache import patch_cache_control
 from django.views.static import serve
 
-from util import response
+from util import response, s3_util
 
 logger = logging.getLogger(__name__)
 
@@ -30,4 +33,27 @@ def cached_serve(request, path, document_root=None, show_indexes=False):
     res = serve(request, path, document_root, show_indexes)
     DAY = 60 * 60 * 24
     patch_cache_control(res, public=True, max_age=30 * DAY)
+    return res
+
+
+def courses_json(request):
+    try:
+        # Get courses.yaml from S3
+        data = s3_util.s3_client.get_object(
+            Bucket=s3_util.s3_bucket_name,
+            Key="courses.yaml",
+        )
+    except ClientError:
+        return response.not_found()
+
+    try:
+        # Convert YAML to JSON
+        converted = yaml.safe_load(data["Body"].read())
+    except yaml.YAMLError as e:
+        logger.error("Error parsing courses.yaml: %s", e)
+        return response.internal_error()
+
+    res = JsonResponse(converted, safe=False)
+    patch_cache_control(res, public=True, max_age=60 * 60 * 24)
+    res["Access-Control-Allow-Origin"] = "*"
     return res


### PR DESCRIPTION
As we plan to obsolete the old Better Informatics, one crucial endpoint that needs to be migrated is `/courses.json`. We plan to do this altering the existing GH workflow for its generation to also upload to our S3 storage, and serve that from BI Files. (Other alternatives included using GitHub as a CDN, which I didn't particularly want to do given its low stability recently)

This PR adds a forward-compatible `courses.json` endpoint that currently returns nothing, but can populate itself from S3 if there is a file there.