### PR TITLE
Fix quotes in PR titles breaking string interpolation in CI

### DIFF
--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -153,8 +153,9 @@ jobs:
       - name: Update PR body with changelog
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RAW_BODY: ${{ steps.changelog.outputs.raw_new }}
         run: |
-          raw_body="${{ steps.changelog.outputs.raw_new }}"
+          raw_body="$RAW_BODY"
           printf '%s\n' '<table><tbody><tr><td>' '' "$raw_body" '' '</td></tr></tbody></table>' '' 'This PR tracks the upcoming release and keeps an automatically generated changelog for it. It auto-rebases when the master branch ref is updated.' '' 'Comment "/release v<version number>" when it is time to release the next version.' 'This will mark the PR as Ready and regenerate the changelog with the specified version. (Note that this will overwrite any manual commits.)' 'After "/release", you can manually edit the changelog if necessary.' 'Finally, squash-merge this PR to create the release.' > pr-body.txt
 
           gh pr edit ${{ github.event.issue.number }} \


### PR DESCRIPTION
We should use the `env` field in CI to pass user-supplied strings into variables, otherwise they can escape the interpolation. #155 broke the CI due to its double quotation marks.