### PR TITLE
Fix visual bugs in grade stat graphs

### DIFF
--- a/frontend/src/components/Charts/CategoryGradeStatChart.tsx
+++ b/frontend/src/components/Charts/CategoryGradeStatChart.tsx
@@ -508,6 +508,69 @@ export const CategoryGradeStatChart: React.FC<
             },
           },
         })),
+        // Std dev vertical error bar if there is only one year,
+        // since area won't render in that case
+        ...codes.map((code, _ix) => ({
+          name: `${code}-stddev-vertical`,
+          type: "custom",
+          silent: true,
+          triggerEvent: false,
+          data: combinedData.map(d => [d.academic_year]),
+          renderItem: (
+            _params: CustomSeriesRenderItemParams,
+            api: CustomSeriesRenderItemAPI,
+          ) => {
+            const xValue = api.value(0);
+            const yValue =
+              combinedData[_params.dataIndex]?.course_code[code]?.mean_mark;
+            const stdDev =
+              combinedData[_params.dataIndex]?.course_code[code]?.std_deviation;
+            if (
+              yValue === null ||
+              yValue === undefined ||
+              stdDev === null ||
+              stdDev === undefined
+            ) {
+              return null;
+            }
+
+            if (combinedData.filter(d => d.course_code[code]).length > 1) {
+              return null;
+            }
+
+            const xCoord = api.coord([xValue, 0])[0];
+            const yCoordLower = api.coord([0, yValue - stdDev])[1];
+            const yCoordUpper = api.coord([0, yValue + stdDev])[1];
+
+            return {
+              type: "line",
+              shape: {
+                x1: xCoord,
+                y1: yCoordLower,
+                x2: xCoord,
+                y2: yCoordUpper,
+              },
+              style: api.style({
+                stroke: colors[codes.indexOf(code) % colors.length].replace(
+                  "0.3",
+                  "0.8",
+                ),
+                lineWidth: 2,
+                opacity: 1,
+              }),
+              emphasis: {
+                style: api.style({
+                  stroke: colors[codes.indexOf(code) % colors.length].replace(
+                    "0.3",
+                    "1.0",
+                  ),
+                  lineWidth: 4,
+                  opacity: 1,
+                }),
+              },
+            };
+          },
+        })),
         // Main line series for each course code
         ...codes.map((code, ix) => ({
           name: code,

--- a/frontend/src/components/Charts/CategoryGradeStatChart.tsx
+++ b/frontend/src/components/Charts/CategoryGradeStatChart.tsx
@@ -372,14 +372,19 @@ export const CategoryGradeStatChart: React.FC<
             ?.getEchartsInstance()
             ?.convertToPixel({ xAxisIndex: 0 }, 0);
           if (gridX === undefined) {
-            return { left: point[0], top: cursorY }; // Fallback to cursor X
+            return { left: point[0] - size.contentSize[0] / 2, top: cursorY }; // Fallback to cursor X
+          }
+
+          if (sortedYears.length === 1) {
+            // prevent division by zero
+            return { left: gridX - size.contentSize[0] / 2, top: cursorY };
           }
 
           const gridXEnd = chartRef
             ?.getEchartsInstance()
             ?.convertToPixel({ xAxisIndex: 0 }, sortedYears.length - 1);
           if (gridXEnd === undefined) {
-            return { left: point[0], top: cursorY }; // Fallback to cursor X
+            return { left: point[0] - size.contentSize[0] / 2, top: cursorY }; // Fallback to cursor X
           }
           const gridW = gridXEnd - gridX;
 

--- a/frontend/src/components/Charts/CategoryGradeStatChart.tsx
+++ b/frontend/src/components/Charts/CategoryGradeStatChart.tsx
@@ -721,17 +721,12 @@ export const CategoryGradeStatChart: React.FC<
 
               const xCoord = api.coord([xValue, 0])[0];
               const yPercentileCoord = api.coord([0, percentile])[1];
-              let len = percentileLength;
-              // shorter for 5th and 95th percentiles
-              if (key === "5" || key === "95") {
-                len = percentileLength / 3;
-              }
               returnVal.children.push({
                 type: "line",
                 shape: {
-                  x1: xCoord - len / 2,
+                  x1: xCoord - percentileLength / 2,
                   y1: yPercentileCoord,
-                  x2: xCoord + len / 2,
+                  x2: xCoord + percentileLength / 2,
                   y2: yPercentileCoord,
                 },
                 style: customStyle,

--- a/frontend/src/components/category-stats.tsx
+++ b/frontend/src/components/category-stats.tsx
@@ -41,45 +41,71 @@ const CategoryStatsComponent: React.FC<CategoryStatsProps> = ({ slug }) => {
     > = {};
     const allCourseCodes = new Set<string>();
 
-    stats.forEach(stat => {
-      yearGroups[stat.academic_year] ??= {};
+    const years = new Set(stats.map(stat => stat.academic_year));
 
-      // Mutable reference
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const yearGroup = yearGroups[stat.academic_year]!;
-      const existingStat = yearGroup[stat.course_code];
+    years.forEach(year => {
+      yearGroups[year] = {};
 
-      // collect a representative stat for every year-course pair, and extras
-      if (!existingStat) {
-        yearGroup[stat.course_code] = stat;
-      } else {
-        // If we already have a stat for this year-course pair, choose the one
-        // with the earliest source_date while having 25/50/75 percentiles and mean;
-        // if that doesn't exist, choose earliest with mean.
-        const existingHasMean = existingStat.mean_mark !== null;
-        const existingHasPercentiles = ["25", "50", "75"].every(
-          p => existingStat.percentiles[p],
+      // Sort stats for this year by source_date ascending
+      const yearStats = stats
+        .filter(stat => stat.academic_year === year)
+        .sort((a, b) => a.source_date.localeCompare(b.source_date));
+
+      yearStats
+        .map(stat => stat.course_code)
+        .forEach(code => allCourseCodes.add(code));
+
+      allCourseCodes.forEach(code => {
+        const courseStats = yearStats.filter(stat => stat.course_code === code);
+
+        const analysed = courseStats.map(stat => {
+          // Check if the stat has all required fields
+          const hasMean = stat.mean_mark !== null;
+          const hasStdDev = stat.std_deviation !== null;
+          const hasMedian = stat.percentiles["50"];
+          const hasQuartiles =
+            hasMedian && ["25", "75"].every(p => stat.percentiles[p]);
+          const has5th95th =
+            hasQuartiles && ["5", "95"].every(p => stat.percentiles[p]);
+          return {
+            stat,
+            hasMean,
+            hasStdDev,
+            hasMedian,
+            hasQuartiles,
+            has5th95th,
+          };
+        });
+
+        let found = analysed.find(
+          a => a.hasMean && a.hasStdDev && a.hasQuartiles,
         );
-        const statHasMean = stat.mean_mark !== null;
-        const statHasPercentiles = ["25", "50", "75"].every(
-          p => stat.percentiles[p],
-        );
-        if (
-          (!existingHasMean && statHasMean) ||
-          (existingHasMean &&
-            statHasMean &&
-            !existingHasPercentiles &&
-            statHasPercentiles) ||
-          (existingHasMean &&
-            statHasMean &&
-            existingHasPercentiles &&
-            statHasPercentiles &&
-            stat.source_date < existingStat.source_date)
-        ) {
-          yearGroup[stat.course_code] = stat;
+        if (found) {
+          // If any stat has all required fields, use that
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          yearGroups[year]![code] = found.stat;
+          return;
         }
-      }
-      allCourseCodes.add(stat.course_code);
+
+        // otherwise, pick the earliest one with the most complete quartile
+        // and combine it with the earliest one with mean and stddev
+        let partial = {};
+        found = analysed.find(a => a.hasMean && a.hasStdDev);
+        if (found) {
+          partial = found.stat;
+        }
+
+        found = analysed.find(a => a.hasQuartiles);
+        if (found) {
+          partial = {
+            ...partial,
+            percentiles: found.stat.percentiles,
+          };
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        yearGroups[year]![code] = partial as CourseStats;
+      });
     });
 
     const sortedYears = Object.keys(yearGroups).sort();


### PR DESCRIPTION
Fixes the following issues with the grade stat chart:
- Unable to see standard deviation if there is only one year a course ran
- Tooltip is placed at a weird position when there is only one year a course ran
- 5/95th percentile lines are hard to see
- Standard deviation lines can be missing if there is a data point with percentiles with no stddev